### PR TITLE
Add install bundle git action

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,19 +72,19 @@ jobs:
           git push --set-upstream origin master
 
       - name: Build Install Bundle
-#        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           export VERSION=$(cat VERSION)
           make install-bundle
 
       - name: Get Version
-#        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         id: vars
         run:
           echo ::set-output name=version::$(cat VERSION)
 
       - name: Create Release
-#        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -97,7 +97,7 @@ jobs:
           prerelease: false
 
       - name: Upload Release Image Bundle
-#        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -103,9 +103,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAR_PATH: "./build/astra-connector-${{ steps.vars.outputs.version }}.tgz"
+          ASSET_NAME: "install-bundle-${{ steps.vars.outputs.version }}.tgz"
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ${{ env.TAR_PATH }}
-          asset_name: install-bundle.tgz
+          asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: application/x-tar
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -92,18 +92,15 @@ jobs:
       - name: Create Release
 #        if: github.ref == 'refs/heads/master'
         id: create_release
-#        uses: actions/create-release@v1
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: "v${{ steps.vars.outputs.version }}"
-        run: |
-          echo ${{ steps.vars.outputs.version }}
-          echo $VERSION
-#        with:
-#          tag_name: ${{ env.VERSION }}
-#          release_name: Release $(cat VERSION)
-#          draft: true
-#          prerelease: false
+        with:
+          tag_name: $VERSION
+          release_name: Release $VERSION
+          draft: true
+          prerelease: false
 
 #        - name: Bump version and push tag
 #          id: tag_version
@@ -111,15 +108,15 @@ jobs:
 #          with:
 #            github_token: ${{ secrets.GITHUB_TOKEN }}
 #
-#      - name: Upload Release Asset
+      - name: Upload Release Image Bundle
 #        if: github.ref == 'refs/heads/add-install-bundle-git-action'
-#        id: upload-release-asset
-#        uses: actions/upload-release-asset@v1
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-#          asset_path: ./my-artifact.zip
-#          asset_name: my-artifact.zip
-#          asset_content_type: application/zip
-#
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./my-artifact.tgz
+          asset_name: my-artifact.tgz
+          asset_content_type: application/zip
+

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,17 +76,20 @@ jobs:
         run: |
           make install-bundle
 
-      - name: Archive Install Bundle
-#        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v3
-        with:
-          name: install-bundle
-          path: |
-            build/astra-connector-*.tgz
+#      - name: Archive Install Bundle
+##        if: github.ref == 'refs/heads/master'
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: install-bundle
+#          path: |
+#            build/astra-connector-*.tgz
 
       - name: Get Version
         id: vars
-        run: echo ::set-output name=version::$(cat VERSION)
+        run:
+          echo ::set-output name=version::$(cat VERSION)
+          
+          echo ::set-output name=version::$(cat VERSION)
 
 
       - name: Create Release
@@ -95,10 +98,10 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: "v${{ steps.vars.outputs.version }}"
+          TAG_VERSION: "v${{ steps.vars.outputs.version }}"
         with:
-          tag_name: $VERSION
-          release_name: Release $VERSION
+          tag_name: $TAG_VERSION
+          release_name: Release $TAG_VERSION
           draft: true
           prerelease: false
 
@@ -114,9 +117,10 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAR_PATH: "./build/astra-connector-${{ steps.vars.outputs.version }}.tgz"
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./build/astra-connector-*.tgz
+          asset_path: $TAR_PATH
           asset_name: install-bundle
           asset_content_type: application/x-tar
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,73 +29,75 @@ jobs:
               dep ensure
           fi
 
-      - name: Unit / L1 Test
-        run: make l1
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.6
-        if: always()
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: out/*_report.xml
-
-      - name: Build Images
-        run: |
-          echo ${{ github.ref }}
-          BASE_VERSION=$(cat version.txt)
-          export VERSION=$BASE_VERSION.$(date -u '+%Y%m%d%H%M')
-          echo $BASE_VERSION
-          echo $VERSION
-          echo $VERSION > VERSION
-          make docker-build
-
-      - name: Deploy to DockerHub
-        if: github.ref == 'refs/heads/master'
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-        run: |
-          export VERSION=$(cat VERSION)
-          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
-          make docker-push
-
-      - name: Update the operator image tag
-        if: github.ref == 'refs/heads/master'
-        run: |
-          export VERSION=$(cat VERSION)
-          make generate
-          make generate-operator-yaml
-          git config --global user.name ${{ secrets.ACTIONS_USER }}
-          git config --global user.email ${{ secrets.ACTIONS_EMAIL }}
-          git diff astraconnector_operator.yaml
-          git add astraconnector_operator.yaml
-          git commit -m "Auto updating the operator image tag" -n
-          git push --set-upstream origin master
-          
-      - name: Build Install Bundle
-        if: github.ref == 'refs/heads/add-install-bundle-git-action'
-        run: |
-          make install-bundle
-
-      - name: Archive Install Bundle
-        if: github.ref == 'refs/heads/add-install-bundle-git-action'
-        uses: actions/upload-artifact@v3
-        with:
-          name: install-bundle
-          path: |
-            build/astra-connector-*.tgz
+#      - name: Unit / L1 Test
+#        run: make l1
+#
+#      - name: Publish Unit Test Results
+#        uses: EnricoMi/publish-unit-test-result-action@v1.6
+#        if: always()
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: out/*_report.xml
+#
+#      - name: Build Images
+#        run: |
+#          BASE_VERSION=$(cat version.txt)
+#          export VERSION=$BASE_VERSION.$(date -u '+%Y%m%d%H%M')
+#          echo $BASE_VERSION
+#          echo $VERSION
+#          echo $VERSION > VERSION
+#          make docker-build
+#
+#      - name: Deploy to DockerHub
+#        if: github.ref == 'refs/heads/master'
+#        env:
+#          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+#          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+#        run: |
+#          export VERSION=$(cat VERSION)
+#          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+#          make docker-push
+#
+#      - name: Update the operator image tag
+#        if: github.ref == 'refs/heads/master'
+#        run: |
+#          export VERSION=$(cat VERSION)
+#          make generate
+#          make generate-operator-yaml
+#          git config --global user.name ${{ secrets.ACTIONS_USER }}
+#          git config --global user.email ${{ secrets.ACTIONS_EMAIL }}
+#          git diff astraconnector_operator.yaml
+#          git add astraconnector_operator.yaml
+#          git commit -m "Auto updating the operator image tag" -n
+#          git push --set-upstream origin master
+#
+#      - name: Build Install Bundle
+##        if: github.ref == 'refs/heads/master'
+#        run: |
+#          make install-bundle
+#
+#      - name: Archive Install Bundle
+##        if: github.ref == 'refs/heads/master'
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: install-bundle
+#          path: |
+#            build/astra-connector-*.tgz
 
       - name: Create Release
-        if: github.ref == 'refs/heads/add-install-bundle-git-action'
+#        if: github.ref == 'refs/heads/master'
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: $(cat VERSION)
-          release_name: Release $(cat VERSION)
-          draft: true
-          prerelease: false
+          VERSION: "v$(cat VERSION)"
+        run: |
+          echo $VERSION
+#        with:
+#          tag_name: ${{ env.VERSION }}
+#          release_name: Release $(cat VERSION)
+#          draft: true
+#          prerelease: false
 
 #        - name: Bump version and push tag
 #          id: tag_version

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           tag_name: ${{ env.TAG_VERSION }}
           release_name: Release ${{ env.TAG_VERSION }}
-          draft: true
+          draft: false
           prerelease: false
 
       - name: Upload Release Image Bundle

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -100,8 +100,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_VERSION: "v${{ steps.vars.outputs.version }}"
         with:
-          tag_name: $TAG_VERSION
-          release_name: Release $TAG_VERSION
+          tag_name: ${{ env.TAG_VERSION }}
+          release_name: Release ${{ env.TAG_VERSION }}
           draft: true
           prerelease: false
 
@@ -120,7 +120,7 @@ jobs:
           TAR_PATH: "./build/astra-connector-${{ steps.vars.outputs.version }}.tgz"
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: $TAR_PATH
+          asset_path: ${{ env.TAR_PATH }}
           asset_name: install-bundle
           asset_content_type: application/x-tar
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,13 +39,13 @@ jobs:
 #          github_token: ${{ secrets.GITHUB_TOKEN }}
 #          files: out/*_report.xml
 #
-#      - name: Build Images
-#        run: |
-#          BASE_VERSION=$(cat version.txt)
-#          export VERSION=$BASE_VERSION.$(date -u '+%Y%m%d%H%M')
-#          echo $BASE_VERSION
-#          echo $VERSION
-#          echo $VERSION > VERSION
+      - name: Build Images
+        run: |
+          BASE_VERSION=$(cat version.txt)
+          export VERSION=$BASE_VERSION.$(date -u '+%Y%m%d%H%M')
+          echo $BASE_VERSION
+          echo $VERSION
+          echo $VERSION > VERSION
 #          make docker-build
 #
 #      - name: Deploy to DockerHub

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,3 +70,8 @@ jobs:
           git add astraconnector_operator.yaml
           git commit -m "Auto updating the operator image tag" -n
           git push --set-upstream origin master
+          
+      - name: Build and Push Install Bundle
+        if: github.ref == 'refs/heads/add-operator-image-to-tar'
+        run: |
+          make install-bundle

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -83,7 +83,6 @@ jobs:
         run:
           echo ::set-output name=version::$(cat VERSION)
 
-
       - name: Create Release
         if: github.ref == 'refs/heads/master'
         id: create_release

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,19 +72,19 @@ jobs:
           git push --set-upstream origin master
 
       - name: Build Install Bundle
-        if: github.ref == 'refs/heads/master'
+#        if: github.ref == 'refs/heads/master'
         run: |
           export VERSION=$(cat VERSION)
           make install-bundle
 
       - name: Get Version
-        if: github.ref == 'refs/heads/master'
+#        if: github.ref == 'refs/heads/master'
         id: vars
         run:
           echo ::set-output name=version::$(cat VERSION)
 
       - name: Create Release
-        if: github.ref == 'refs/heads/master'
+#        if: github.ref == 'refs/heads/master'
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -97,7 +97,7 @@ jobs:
           prerelease: false
 
       - name: Upload Release Image Bundle
-        if: github.ref == 'refs/heads/master'
+#        if: github.ref == 'refs/heads/master'
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Create Release
 #        if: github.ref == 'refs/heads/master'
         id: create_release
-        uses: actions/create-release@v1
+#        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: "v$(cat VERSION)"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,6 +72,6 @@ jobs:
           git push --set-upstream origin master
           
       - name: Build and Push Install Bundle
-        if: github.ref == 'refs/heads/add-operator-image-to-tar'
+#        if: github.ref == 'refs/heads/add-operator-image-to-tar'
         run: |
           make install-bundle

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build Images
         run: |
-          echo github.ref
+          echo ${{ github.ref }}
           BASE_VERSION=$(cat version.txt)
           export VERSION=$BASE_VERSION.$(date -u '+%Y%m%d%H%M')
           echo $BASE_VERSION

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,27 +72,20 @@ jobs:
           git push --set-upstream origin master
 
       - name: Build Install Bundle
-#        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           export VERSION=$(cat VERSION)
           make install-bundle
 
-#      - name: Archive Install Bundle
-##        if: github.ref == 'refs/heads/master'
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: install-bundle
-#          path: |
-#            build/astra-connector-*.tgz
-
       - name: Get Version
+        if: github.ref == 'refs/heads/master'
         id: vars
         run:
           echo ::set-output name=version::$(cat VERSION)
 
 
       - name: Create Release
-#        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -104,14 +97,8 @@ jobs:
           draft: true
           prerelease: false
 
-#        - name: Bump version and push tag
-#          id: tag_version
-#          uses: mathieudutour/github-tag-action@v6.0
-#          with:
-#            github_token: ${{ secrets.GITHUB_TOKEN }}
-#
       - name: Upload Release Image Bundle
-#        if: github.ref == 'refs/heads/add-install-bundle-git-action'
+        if: github.ref == 'refs/heads/master'
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Build Images
         run: |
+          echo github.ref
           BASE_VERSION=$(cat version.txt)
           export VERSION=$BASE_VERSION.$(date -u '+%Y%m%d%H%M')
           echo $BASE_VERSION

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,14 +72,45 @@ jobs:
           git push --set-upstream origin master
           
       - name: Build Install Bundle
-#        if: github.ref == 'refs/heads/add-operator-image-to-tar'
+        if: github.ref == 'refs/heads/add-install-bundle-git-action'
         run: |
           make install-bundle
 
       - name: Archive Install Bundle
+        if: github.ref == 'refs/heads/add-install-bundle-git-action'
         uses: actions/upload-artifact@v3
         with:
           name: install-bundle
           path: |
             build/astra-connector-*.tgz
 
+      - name: Create Release
+        if: github.ref == 'refs/heads/add-install-bundle-git-action'
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: $(cat VERSION)
+          release_name: Release $(cat VERSION)
+          draft: true
+          prerelease: false
+
+#        - name: Bump version and push tag
+#          id: tag_version
+#          uses: mathieudutour/github-tag-action@v6.0
+#          with:
+#            github_token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Upload Release Asset
+#        if: github.ref == 'refs/heads/add-install-bundle-git-action'
+#        id: upload-release-asset
+#        uses: actions/upload-release-asset@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+#          asset_path: ./my-artifact.zip
+#          asset_name: my-artifact.zip
+#          asset_content_type: application/zip
+#

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_and_test:
-    name: CICD tests
+    name: CICD
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
@@ -46,6 +46,7 @@ jobs:
           echo $BASE_VERSION
           echo $VERSION
           echo $VERSION > VERSION
+          echo ::set-output name=version::$(cat VERSION)
           make docker-build
 
       - name: Deploy to DockerHub
@@ -74,6 +75,7 @@ jobs:
       - name: Build Install Bundle
 #        if: github.ref == 'refs/heads/master'
         run: |
+          export VERSION=$(cat VERSION)
           make install-bundle
 
 #      - name: Archive Install Bundle
@@ -84,12 +86,10 @@ jobs:
 #          path: |
 #            build/astra-connector-*.tgz
 
-      - name: Get Version
-        id: vars
-        run:
-          echo ::set-output name=version::$(cat VERSION)
-          
-          echo ::set-output name=version::$(cat VERSION)
+#      - name: Get Version
+#        id: vars
+#        run:
+#          echo ::set-output name=version::$(cat VERSION)
 
 
       - name: Create Release

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: CICD
 
 on:
   push:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,16 +29,16 @@ jobs:
               dep ensure
           fi
 
-#      - name: Unit / L1 Test
-#        run: make l1
-#
-#      - name: Publish Unit Test Results
-#        uses: EnricoMi/publish-unit-test-result-action@v1.6
-#        if: always()
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: out/*_report.xml
-#
+      - name: Unit / L1 Test
+        run: make l1
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: out/*_report.xml
+
       - name: Build Images
         run: |
           BASE_VERSION=$(cat version.txt)
@@ -46,43 +46,43 @@ jobs:
           echo $BASE_VERSION
           echo $VERSION
           echo $VERSION > VERSION
-#          make docker-build
-#
-#      - name: Deploy to DockerHub
+          make docker-build
+
+      - name: Deploy to DockerHub
+        if: github.ref == 'refs/heads/master'
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: |
+          export VERSION=$(cat VERSION)
+          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+          make docker-push
+
+      - name: Update the operator image tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          export VERSION=$(cat VERSION)
+          make generate
+          make generate-operator-yaml
+          git config --global user.name ${{ secrets.ACTIONS_USER }}
+          git config --global user.email ${{ secrets.ACTIONS_EMAIL }}
+          git diff astraconnector_operator.yaml
+          git add astraconnector_operator.yaml
+          git commit -m "Auto updating the operator image tag" -n
+          git push --set-upstream origin master
+
+      - name: Build Install Bundle
 #        if: github.ref == 'refs/heads/master'
-#        env:
-#          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-#          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-#        run: |
-#          export VERSION=$(cat VERSION)
-#          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
-#          make docker-push
-#
-#      - name: Update the operator image tag
+        run: |
+          make install-bundle
+
+      - name: Archive Install Bundle
 #        if: github.ref == 'refs/heads/master'
-#        run: |
-#          export VERSION=$(cat VERSION)
-#          make generate
-#          make generate-operator-yaml
-#          git config --global user.name ${{ secrets.ACTIONS_USER }}
-#          git config --global user.email ${{ secrets.ACTIONS_EMAIL }}
-#          git diff astraconnector_operator.yaml
-#          git add astraconnector_operator.yaml
-#          git commit -m "Auto updating the operator image tag" -n
-#          git push --set-upstream origin master
-#
-#      - name: Build Install Bundle
-##        if: github.ref == 'refs/heads/master'
-#        run: |
-#          make install-bundle
-#
-#      - name: Archive Install Bundle
-##        if: github.ref == 'refs/heads/master'
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: install-bundle
-#          path: |
-#            build/astra-connector-*.tgz
+        uses: actions/upload-artifact@v3
+        with:
+          name: install-bundle
+          path: |
+            build/astra-connector-*.tgz
 
       - name: Get Version
         id: vars
@@ -116,7 +116,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./my-artifact.tgz
-          asset_name: my-artifact.tgz
-          asset_content_type: application/zip
+          asset_path: ./build/astra-connector-*.tgz
+          asset_name: install-bundle
+          asset_content_type: application/x-tar
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -84,14 +84,20 @@ jobs:
 #          path: |
 #            build/astra-connector-*.tgz
 
+      - name: Get Version
+        id: vars
+        run: echo ::set-output name=version::$(cat VERSION)
+
+
       - name: Create Release
 #        if: github.ref == 'refs/heads/master'
         id: create_release
 #        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: "v$(cat VERSION)"
+          VERSION: "v${{ steps.vars.outputs.version }}"
         run: |
+          echo ${{ steps.vars.outputs.version }}
           echo $VERSION
 #        with:
 #          tag_name: ${{ env.VERSION }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -71,7 +71,15 @@ jobs:
           git commit -m "Auto updating the operator image tag" -n
           git push --set-upstream origin master
           
-      - name: Build and Push Install Bundle
+      - name: Build Install Bundle
 #        if: github.ref == 'refs/heads/add-operator-image-to-tar'
         run: |
           make install-bundle
+
+      - name: Archive Install Bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: install-bundle
+          path: |
+            build/astra-connector-*.tgz
+

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -104,8 +104,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAR_PATH: "./build/astra-connector-${{ steps.vars.outputs.version }}.tgz"
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ${{ env.TAR_PATH }}
-          asset_name: install-bundle
+          asset_name: install-bundle.tgz
           asset_content_type: application/x-tar
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,7 +46,6 @@ jobs:
           echo $BASE_VERSION
           echo $VERSION
           echo $VERSION > VERSION
-          echo ::set-output name=version::$(cat VERSION)
           make docker-build
 
       - name: Deploy to DockerHub
@@ -86,10 +85,10 @@ jobs:
 #          path: |
 #            build/astra-connector-*.tgz
 
-#      - name: Get Version
-#        id: vars
-#        run:
-#          echo ::set-output name=version::$(cat VERSION)
+      - name: Get Version
+        id: vars
+        run:
+          echo ::set-output name=version::$(cat VERSION)
 
 
       - name: Create Release

--- a/Makefile
+++ b/Makefile
@@ -231,18 +231,16 @@ image-tar:
 	$(SCRIPTS_DIR)/create-image-tar.sh ${OUTPUT_IMAGE_TAR_DIR}/astra-connector-images.tar
 
 
-GOOS_LINUX=linux
-GOARCH_LINUX=amd64
-install-exe-linux-amd: export GOOS=${GOOS_LINUX}
-install-exe-linux-amd: export GOARCH=${GOARCH_LINUX}
-install-exe-linux-amd: export CGO_ENABLED=0
-install-exe-linux-amd: export GO111MODULE=on
-install-exe-linux-amd: install-exe
-
-install-exe:
+install-exes: export CGO_ENABLED=0
+install-exes: export GO111MODULE=on
+install-exes:
 	rm -rf $(OUTPUT_INSTALL_EXE_DIR)
 	mkdir -p $(OUTPUT_INSTALL_EXE_DIR)
-	cd $(INSTALL_DIR) && go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install-${VERSION}-${GOARCH}-${GOOS} ${INSTALL_DIR}/install.go
+	cd $(INSTALL_DIR); \
+	export GOOS=linux; export GOARCH=amd64; go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install_${VERSION}_$${GOARCH}_$${GOOS} ${INSTALL_DIR}/install.go; \
+	export GOOS=darwin; export GOARCH=amd64; go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install_${VERSION}_$${GOARCH}_$${GOOS} ${INSTALL_DIR}/install.go; \
+	export GOOS=darwin; export GOARCH=arm64; go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install_${VERSION}_$${GOARCH}_$${GOOS} ${INSTALL_DIR}/install.go; \
+	export GOOS=windows; export GOARCH=amd64; go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install_${VERSION}_$${GOARCH}_$${GOOS}.exe ${INSTALL_DIR}/install.go
 
 bundle-base:
 	rm -rf $(BUILD_DIR)/*.tgz # Remove existing tgz bundles
@@ -254,5 +252,5 @@ bundle-base:
 	cp ${MAKEFILE_DIR}/astraconnector_operator.yaml $(INSTALL_BUNDLE_DIR)/astraconnector_operator.yaml
 
 
-install-bundle: image-tar install-exe-linux-amd bundle-base
+install-bundle: image-tar install-exes bundle-base
 	cd $(INSTALL_BUNDLE_DIR) && tar -zcf $(BUILD_DIR)/astra-connector-${VERSION}.tgz .

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BUILD_DIR := $(MAKEFILE_DIR)/build
 OUTPUT_IMAGE_TAR_DIR := $(BUILD_DIR)/images
 INSTALL_DIR := $(MAKEFILE_DIR)/installer
 OUTPUT_INSTALL_EXE_DIR := $(BUILD_DIR)/install-exe
+INSTALL_BUNDLE_DIR = $(BUILD_DIR)/install-bundle
 
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
@@ -246,3 +247,14 @@ install-exe:
 	rm -rf $(OUTPUT_INSTALL_EXE_DIR)
 	mkdir -p $(OUTPUT_INSTALL_EXE_DIR)
 	cd $(INSTALL_DIR) && go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${BUILD_VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install-${GOARCH}-${GOOS} ${INSTALL_DIR}/install.go
+
+bundle-base:
+	rm -rf $(BUILD_DIR)/*.tgz # Remove existing tgz bundles
+	rm -rf $(INSTALL_BUNDLE_DIR)
+	mkdir -p $(INSTALL_BUNDLE_DIR)
+	cp ${OUTPUT_INSTALL_EXE_DIR}/* $(INSTALL_BUNDLE_DIR)
+	cp ${OUTPUT_IMAGE_TAR_DIR}/astra-connector-images.tar $(INSTALL_BUNDLE_DIR)
+
+
+install-bundle: image-tar install-exe-linux-amd bundle-base
+	cd $(INSTALL_BUNDLE_DIR) && tar -zcf $(BUILD_DIR)/astra-connector-${BUILD_VERSION}.tgz .

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ install-exe-linux-amd: install-exe
 install-exe:
 	rm -rf $(OUTPUT_INSTALL_EXE_DIR)
 	mkdir -p $(OUTPUT_INSTALL_EXE_DIR)
-	cd $(INSTALL_DIR) && go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install-${GOARCH}-${GOOS} ${INSTALL_DIR}/install.go
+	cd $(INSTALL_DIR) && go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install-${VERSION}-${GOARCH}-${GOOS} ${INSTALL_DIR}/install.go
 
 bundle-base:
 	rm -rf $(BUILD_DIR)/*.tgz # Remove existing tgz bundles

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,8 @@ bundle-base:
 	mkdir -p $(INSTALL_BUNDLE_DIR)
 	cp ${OUTPUT_INSTALL_EXE_DIR}/* $(INSTALL_BUNDLE_DIR)
 	cp ${OUTPUT_IMAGE_TAR_DIR}/astra-connector-images.tar $(INSTALL_BUNDLE_DIR)
+	cp ${MAKEFILE_DIR}/controllerconfig.yaml $(INSTALL_BUNDLE_DIR)/controllerconfig.yaml
+	cp ${MAKEFILE_DIR}/astraconnector_operator.yaml $(INSTALL_BUNDLE_DIR)/astraconnector_operator.yaml
 
 
 install-bundle: image-tar install-exe-linux-amd bundle-base

--- a/Makefile
+++ b/Makefile
@@ -230,10 +230,6 @@ image-tar:
 	mkdir -p ${OUTPUT_IMAGE_TAR_DIR}
 	$(SCRIPTS_DIR)/create-image-tar.sh ${OUTPUT_IMAGE_TAR_DIR}/astra-connector-images.tar
 
-# Versioning vars
-BASE_VERSION := $(shell cat "${MAKEFILE_DIR}/version.txt")
-BUILD_DATE := $(shell date '+%Y%m%d%H%M')
-BUILD_VERSION := ${BASE_VERSION}.${BUILD_DATE}
 
 GOOS_LINUX=linux
 GOARCH_LINUX=amd64
@@ -246,7 +242,7 @@ install-exe-linux-amd: install-exe
 install-exe:
 	rm -rf $(OUTPUT_INSTALL_EXE_DIR)
 	mkdir -p $(OUTPUT_INSTALL_EXE_DIR)
-	cd $(INSTALL_DIR) && go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${BUILD_VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install-${GOARCH}-${GOOS} ${INSTALL_DIR}/install.go
+	cd $(INSTALL_DIR) && go build -ldflags "-X github.com/NetApp/astra-connector-operator/installer/install.VERSION=${VERSION}" -v -o ${OUTPUT_INSTALL_EXE_DIR}/install-${GOARCH}-${GOOS} ${INSTALL_DIR}/install.go
 
 bundle-base:
 	rm -rf $(BUILD_DIR)/*.tgz # Remove existing tgz bundles
@@ -257,4 +253,4 @@ bundle-base:
 
 
 install-bundle: image-tar install-exe-linux-amd bundle-base
-	cd $(INSTALL_BUNDLE_DIR) && tar -zcf $(BUILD_DIR)/astra-connector-${BUILD_VERSION}.tgz .
+	cd $(INSTALL_BUNDLE_DIR) && tar -zcf $(BUILD_DIR)/astra-connector-${VERSION}.tgz .

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ image-tar:
 	$(SCRIPTS_DIR)/create-image-tar.sh ${OUTPUT_IMAGE_TAR_DIR}/astra-connector-images.tar
 
 # Versioning vars
-BASE_VERSION := $(shell cat "${REGISTER_DIR}/version.txt")
+BASE_VERSION := $(shell cat "${MAKEFILE_DIR}/version.txt")
 BUILD_DATE := $(shell date '+%Y%m%d%H%M')
 BUILD_VERSION := ${BASE_VERSION}.${BUILD_DATE}
 


### PR DESCRIPTION
Additions to github actions:

When building on master:
* Builds an install bundle with install exe and image tar
* Creates a Github Draft Release, using the install bundle as an artifact there
* Install bundle is versioned the same as the operator

In order to create the full release, one of us just needs to navigate to the releases page and click the button.

Example Draft Release: https://github.com/NetApp/astra-connector-operator/releases