### PR TITLE
ASTRACTL-27146 - adds sample CR to bundle yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ bundle-base:
 	cp ${OUTPUT_IMAGE_TAR_DIR}/astra-connector-images.tar $(INSTALL_BUNDLE_DIR)
 	cp ${MAKEFILE_DIR}/controllerconfig.yaml $(INSTALL_BUNDLE_DIR)/controllerconfig.yaml
 	cp ${MAKEFILE_DIR}/astraconnector_operator.yaml $(INSTALL_BUNDLE_DIR)/astraconnector_operator.yaml
+	cp ${MAKEFILE_DIR}/config/samples/astraconnector_v1.yaml $(INSTALL_BUNDLE_DIR)/astraconnector_v1.yaml
 
 
 install-bundle: image-tar install-exes bundle-base


### PR DESCRIPTION
Ignore the branch name, I'm going to handle versioning in a separate PR.

This adds a sample operator CR to the release bundle that is created on pushes to master. This is required for downstream CICD pipelines that will want to consume a bundle that contains all of the pieces it needs to deploy the connector operator.

We may also want to add a convenience script for deploying that replaces the fields in the sample CR with params provided by the user. TBD