### PR TITLE
Updating Default of Images

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -5,18 +5,18 @@
 package common
 
 const (
-	DefaultImageRegistry = "theotw"
+	DefaultImageRegistry = "docker.io"
 
 	AstraConnectName            = "astraconnect"
 	AstraConnectDefaultReplicas = 1
-	AstraConnectDefaultImage    = "astra-connector:0.3"
+	AstraConnectDefaultImage    = "netapp/astra-connector:1.0.202306162024"
 
 	NatsSyncClientName                  = "natssync-client"
 	NatsSyncClientDefaultReplicas       = 1
 	NatsSyncClientPort                  = 8080
 	NatsSyncClientProtocol              = "TCP"
 	NatsSyncClientKeystoreUrl           = "configmap:///configmap-data"
-	NatsSyncClientDefaultImage          = "natssync-client:0.9.202202170408"
+	NatsSyncClientDefaultImage          = "theotw/natssync-client:2.1.202305182124"
 	NatsSyncClientDefaultCloudBridgeURL = "https://astra.netapp.io"
 
 	NatsName               = "nats"
@@ -30,7 +30,7 @@ const (
 	NatsMetricsPort        = 7777
 	NatsGatewaysPort       = 7522
 	NatsDefaultReplicas    = 2
-	NatsDefaultImage       = "nats:2.6.1-alpine3.14"
+	NatsDefaultImage       = "nats:2.8.4-alpine3.15"
 
 	NatsSyncClientConfigMapName               = "natssync-client-configmap"
 	NatsSyncClientConfigMapRoleName           = "natssync-client-configmap-role"

--- a/deployer/connector/astra_connect_test.go
+++ b/deployer/connector/astra_connect_test.go
@@ -94,7 +94,7 @@ func TestAstraConnectGetDeploymentObjectsUsingDefaults(t *testing.T) {
 	assert.Equal(t, common.AstraConnectName, deployment.Spec.Template.Spec.ServiceAccountName)
 
 	container := deployment.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, "theotw/astra-connector:0.3", container.Image)
+	assert.Equal(t, "docker.io/netapp/astra-connector:1.0.202306162024", container.Image)
 	assert.Equal(t, common.AstraConnectName, container.Name)
 
 	assert.Equal(t, 2, len(container.Env))

--- a/deployer/connector/nats_test.go
+++ b/deployer/connector/nats_test.go
@@ -76,7 +76,7 @@ func TestNatsGetStatefulSetObjectsUseDefaults(t *testing.T) {
 	assert.Equal(t, common.NatsName, statefulSet.Name)
 	assert.Equal(t, m.Namespace, statefulSet.Namespace)
 	assert.Equal(t, int32(2), *statefulSet.Spec.Replicas)
-	assert.Equal(t, "nats:2.6.1-alpine3.14", statefulSet.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "nats:2.8.4-alpine3.15", statefulSet.Spec.Template.Spec.Containers[0].Image)
 	assert.Nil(t, statefulSet.Spec.Template.Spec.ImagePullSecrets)
 }
 

--- a/deployer/connector/natssync_client_test.go
+++ b/deployer/connector/natssync_client_test.go
@@ -68,7 +68,7 @@ func TestNatsSyncGetDeploymentObjectsDefault(t *testing.T) {
 	assert.True(t, ok)
 
 	assert.Equal(t, int32(1), *deployment.Spec.Replicas)
-	assert.Equal(t, "theotw/natssync-client:0.9.202202170408", deployment.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "docker.io/theotw/natssync-client:2.1.202305182124", deployment.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, "192.168.1.1", deployment.Spec.Template.Spec.HostAliases[0].IP)
 	assert.Nil(t, deployment.Spec.Template.Spec.ImagePullSecrets)
 	// TODO add more checks

--- a/details/operator-sdk/config/samples/astra_v1_astraconnector.yaml
+++ b/details/operator-sdk/config/samples/astra_v1_astraconnector.yaml
@@ -11,8 +11,5 @@ spec:
   natsSyncClient:
     cloudBridgeURL: https://integration.astra.netapp.io
     hostAliasIP: 10.193.60.80
-    image: natssync-client:2.0
-  nats:
-    image: nats:2.6.1-alpine3.14
   imageRegistry:
-    name: docker.repo.eng.netapp.com/oscarr/neptune
+    name: docker.repo.eng.netapp.com/oscarr/arch3.0


### PR DESCRIPTION
Updating default images so it matches what is in docker.io and in my docker.repo.eng.netapp.com/oscarr/arch3.0. Now the users won't need to specify images unless they want to test a different non default image. And the only difference between docker.io and internal image is you'll need a secret to pull connector image from docker.io