### PR TITLE
Astractl 27847 limits to match acc operator

### DIFF
--- a/details/operator-sdk/astraconnector_operator.yaml
+++ b/details/operator-sdk/astraconnector_operator.yaml
@@ -440,11 +440,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 200m
-            memory: 100Mi
+            cpu: 300m
+            memory: 750Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 75Mi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:


### PR DESCRIPTION
Hitting an issue in OCP where the operator is just above the memory: 100Mi. We need to set these limit highers, will set to match acc operator for now with a spike later on in phase two when we include deployment of Neptune too.