### PR TITLE
ASTRACTL-27894 bump nats max_payload

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -31,6 +31,7 @@ const (
 	NatsGatewaysPort       = 7522
 	NatsDefaultReplicas    = 2
 	NatsDefaultImage       = "nats:2.8.4-alpine3.15"
+	NatsMaxPayload         = 8388608
 
 	NatsSyncClientConfigMapName               = "natssync-client-configmap"
 	NatsSyncClientConfigMapRoleName           = "natssync-client-configmap-role"

--- a/deployer/connector/nats.go
+++ b/deployer/connector/nats.go
@@ -161,14 +161,14 @@ func (n *NatsDeployer) GetStatefulSetObjects(m *v1.AstraConnector, ctx context.C
 
 // GetConfigMapObjects returns a ConfigMap object for nats
 func (n *NatsDeployer) GetConfigMapObjects(m *v1.AstraConnector, ctx context.Context) ([]client.Object, error) {
-	natsConf := "pid_file: \"/var/run/nats/nats.pid\"\nhttp: %d\n\ncluster {\n  port: %d\n  routes [\n    nats://nats-0.nats-cluster:%d\n    nats://nats-1.nats-cluster:%d\n    nats://nats-2.nats-cluster:%d\n  ]\n\n  cluster_advertise: $CLUSTER_ADVERTISE\n  connect_retries: 30\n}\n"
+	natsConf := "pid_file: \"/var/run/nats/nats.pid\"\nhttp: %d\nmax_payload: %d\n\n cluster {\n  port: %d\n  routes [\n    nats://nats-0.nats-cluster:%d\n    nats://nats-1.nats-cluster:%d\n    nats://nats-2.nats-cluster:%d\n  ]\n\n  cluster_advertise: $CLUSTER_ADVERTISE\n  connect_retries: 30\n}\n"
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: m.Namespace,
 			Name:      common.NatsConfigMapName,
 		},
 		Data: map[string]string{
-			"nats.conf": fmt.Sprintf(natsConf, common.NatsMonitorPort, common.NatsClusterPort, common.NatsClusterPort, common.NatsClusterPort, common.NatsClusterPort),
+			"nats.conf": fmt.Sprintf(natsConf, common.NatsMonitorPort, common.NatsMaxPayload, common.NatsClusterPort, common.NatsClusterPort, common.NatsClusterPort, common.NatsClusterPort),
 		},
 	}
 	return []client.Object{configMap}, nil

--- a/deployer/connector/nats.go
+++ b/deployer/connector/nats.go
@@ -161,7 +161,7 @@ func (n *NatsDeployer) GetStatefulSetObjects(m *v1.AstraConnector, ctx context.C
 
 // GetConfigMapObjects returns a ConfigMap object for nats
 func (n *NatsDeployer) GetConfigMapObjects(m *v1.AstraConnector, ctx context.Context) ([]client.Object, error) {
-	natsConf := "pid_file: \"/var/run/nats/nats.pid\"\nhttp: %d\nmax_payload: %d\n\n cluster {\n  port: %d\n  routes [\n    nats://nats-0.nats-cluster:%d\n    nats://nats-1.nats-cluster:%d\n    nats://nats-2.nats-cluster:%d\n  ]\n\n  cluster_advertise: $CLUSTER_ADVERTISE\n  connect_retries: 30\n}\n"
+	natsConf := "pid_file: \"/var/run/nats/nats.pid\"\nhttp: %d\nmax_payload: %d\n\ncluster {\n  port: %d\n  routes [\n    nats://nats-0.nats-cluster:%d\n    nats://nats-1.nats-cluster:%d\n    nats://nats-2.nats-cluster:%d\n  ]\n\n  cluster_advertise: $CLUSTER_ADVERTISE\n  connect_retries: 30\n}\n"
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: m.Namespace,

--- a/deployer/connector/nats_test.go
+++ b/deployer/connector/nats_test.go
@@ -96,7 +96,7 @@ func TestNatsGetConfigMapObjects(t *testing.T) {
 	// Todo Add assertions for the expected values in the ConfigMap object
 	assert.Equal(t, common.NatsConfigMapName, configMap.Name)
 	assert.Equal(t, m.Namespace, configMap.Namespace)
-	data := map[string]string{"nats.conf": "pid_file: \"/var/run/nats/nats.pid\"\nhttp: 8222\n\ncluster {\n  port: 6222\n  routes [\n    nats://nats-0.nats-cluster:6222\n    nats://nats-1.nats-cluster:6222\n    nats://nats-2.nats-cluster:6222\n  ]\n\n  cluster_advertise: $CLUSTER_ADVERTISE\n  connect_retries: 30\n}\n"}
+	data := map[string]string{"nats.conf": "pid_file: \"/var/run/nats/nats.pid\"\nhttp: 8222\nmax_payload: 8388608\n\ncluster {\n  port: 6222\n  routes [\n    nats://nats-0.nats-cluster:6222\n    nats://nats-1.nats-cluster:6222\n    nats://nats-2.nats-cluster:6222\n  ]\n\n  cluster_advertise: $CLUSTER_ADVERTISE\n  connect_retries: 30\n}\n"}
 	assert.Equal(t, data, configMap.Data)
 }
 


### PR DESCRIPTION
On openshift, we observed that the default 1MB nats payload size is not good enough. this bumps the nats payload size to 8mb

Testing - deployed nats_config:
```
code/astra-connector-operator [bump-nats-payload-size●] » k get cm -n astra-connector nats-configmap -o yaml
apiVersion: v1
data:
  nats.conf: |
    pid_file: "/var/run/nats/nats.pid"
    http: 8222
    max_payload: 8388608

     cluster {
      port: 6222
      routes [
        nats://nats-0.nats-cluster:6222
        nats://nats-1.nats-cluster:6222
        nats://nats-2.nats-cluster:6222
      ]

      cluster_advertise: $CLUSTER_ADVERTISE
      connect_retries: 30
    }
```