### PR TITLE
Astractl 27233 - Skip nats and astra registration based on feature flag

### DIFF
--- a/.config.yaml.sample
+++ b/.config.yaml.sample
@@ -18,3 +18,4 @@ HealthProbePort: 8083
 FeatureFlags:
    DeployNatsConnector: true
    DeployNeptune: false
+   SkipAstraRegistration: false

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,7 +66,7 @@ jobs:
           hide_complexity: true
           indicators: false
           output: both
-          thresholds: '50 80'
+          thresholds: '75 85'
 
       - name: Add coverage PR comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -71,8 +71,9 @@ func DefaultConfiguration() *MutableConfiguration {
 		HealthProbePort:         8081,
 		WaitDurationForResource: 2 * time.Minute,
 		FeatureFlags: featureFlags{
-			DeployNatsConnector: true,
-			DeployNeptune:       false,
+			DeployNatsConnector:   true,
+			DeployNeptune:         false,
+			SkipAstraRegistration: false,
 		},
 	}
 }
@@ -87,8 +88,9 @@ func toImmutableConfig(config *MutableConfiguration) *ImmutableConfiguration {
 		healthProbePort:         config.HealthProbePort,
 		waitDurationForResource: config.WaitDurationForResource,
 		featureFlags: ImmutableFeatureFlags{
-			deployNatsConnector: config.FeatureFlags.DeployNatsConnector,
-			deployNeptune:       config.FeatureFlags.DeployNeptune,
+			deployNatsConnector:   config.FeatureFlags.DeployNatsConnector,
+			deployNeptune:         config.FeatureFlags.DeployNeptune,
+			skipAstraRegistration: config.FeatureFlags.SkipAstraRegistration,
 		},
 		config: config,
 	}
@@ -130,13 +132,15 @@ func (i ImmutableConfiguration) FeatureFlags() ImmutableFeatureFlags {
 }
 
 type ImmutableFeatureFlags struct {
-	deployNatsConnector bool
-	deployNeptune       bool
+	deployNatsConnector   bool
+	deployNeptune         bool
+	skipAstraRegistration bool
 }
 
 type featureFlags struct {
-	DeployNatsConnector bool
-	DeployNeptune       bool
+	DeployNatsConnector   bool
+	DeployNeptune         bool
+	SkipAstraRegistration bool
 }
 
 func (f ImmutableFeatureFlags) DeployNatsConnector() bool {
@@ -145,6 +149,10 @@ func (f ImmutableFeatureFlags) DeployNatsConnector() bool {
 
 func (f ImmutableFeatureFlags) DeployNeptune() bool {
 	return f.deployNeptune
+}
+
+func (f ImmutableFeatureFlags) SkipAstraRegistration() bool {
+	return f.skipAstraRegistration
 }
 
 // Viper configuration

--- a/details/operator-sdk/controllers/astraconnector_controller.go
+++ b/details/operator-sdk/controllers/astraconnector_controller.go
@@ -125,8 +125,8 @@ func (r *AstraConnectorController) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	k8sUtil := k8s.NewK8sUtil(r.Client, log)
-	precheckClient := precheck.NewPrecheckClient(log, k8sUtil)
-	precheckClient.Run()
+	preCheckClient := precheck.NewPrecheckClient(log, k8sUtil)
+	preCheckClient.Run()
 
 	// deploy Neptune
 	if conf.Config.FeatureFlags().DeployNeptune() {

--- a/details/operator-sdk/controllers/connector.go
+++ b/details/operator-sdk/controllers/connector.go
@@ -66,6 +66,8 @@ func (r *AstraConnectorController) deployConnector(ctx context.Context,
 		// Check the feature flag first
 		if conf.Config.FeatureFlags().SkipAstraRegistration() {
 			log.Info("Skipping Nats and Astra registration, feature flag set to not register")
+			natsSyncClientStatus.Status = DeployedComponents
+			_ = r.updateAstraConnectorStatus(ctx, astraConnector, *natsSyncClientStatus)
 			return ctrl.Result{}, nil
 		}
 

--- a/details/operator-sdk/controllers/connector.go
+++ b/details/operator-sdk/controllers/connector.go
@@ -10,6 +10,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/NetApp-Polaris/astra-connector-operator/app/conf"
 	"github.com/NetApp-Polaris/astra-connector-operator/app/deployer/connector"
 	"github.com/NetApp-Polaris/astra-connector-operator/app/deployer/model"
 	"github.com/NetApp-Polaris/astra-connector-operator/app/register"
@@ -62,6 +63,12 @@ func (r *AstraConnectorController) deployConnector(ctx context.Context,
 
 	// RegisterClient
 	if !astraConnector.Spec.Astra.Unregister {
+		// Check the feature flag first
+		if conf.Config.FeatureFlags().SkipAstraRegistration() {
+			log.Info("Skipping Nats and Astra registration, feature flag set to not register")
+			return ctrl.Result{}, nil
+		}
+
 		if registered {
 			log.Info("natsSyncClient already registered", "astraConnectorID", astraConnectorID)
 		} else {

--- a/details/operator-sdk/controllers/status_strings.go
+++ b/details/operator-sdk/controllers/status_strings.go
@@ -34,6 +34,7 @@ const (
 	UnregisterNSClient       = "Unregistered natsSyncClient"
 	FailedUnRegisterNSClient = "Failed to unregister natsSyncClient"
 
+	DeployedComponents  = "Deployed all the connector components"
 	UnregisterFromAstra = "Unregistered the cluster with Astra"
 
 	FailedConnectorIDAdd    = "Failed to add cluster to Astra"


### PR DESCRIPTION
Skip connector registration with nats and astra when `SkipAstraRegistration` feature flag is set to `true`. This is for internal use only and will be set to false by default