### PR TITLE
add manifest file

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -144,12 +144,13 @@ jobs:
           make release
 
       - name: Build default-image manifest file
-        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'ASTRACTL-27664-add-default-image-manifest' || startsWith(github.ref, 'refs/heads/release-') }}
         run: |
           export VERSION=$(cat VERSION)
           export MANIFEST_FILEPATH=./default-image-manifest-$VERSION.manifest
           echo "MANIFEST_FILEPATH=$MANIFEST_FILEPATH" >> $GITHUB_ENV
           go run scripts/create_default_images_manifest.go $MANIFEST_FILEPATH
+          cat $MANIFEST_FILEPATH
 
       - name: Get Version
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload default-image manifest
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
-        id: upload-astraconnector-yaml
+        id: upload-manifest
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -144,7 +144,7 @@ jobs:
           make release
 
       - name: Build default-image manifest file
-#        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
         run: |
           export VERSION=$(cat VERSION)
           export MANIFEST_FILEPATH=./default-image-manifest-$VERSION.manifest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -144,7 +144,7 @@ jobs:
           make release
 
       - name: Build default-image manifest file
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'ASTRACTL-27664-add-default-image-manifest' || startsWith(github.ref, 'refs/heads/release-') }}
+#        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
         run: |
           export VERSION=$(cat VERSION)
           export MANIFEST_FILEPATH=./default-image-manifest-$VERSION.manifest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -147,7 +147,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
         run: |
           export VERSION=$(cat VERSION)
-          export MANIFEST_FILEPATH=./default-image-manifest-$VERSION.txt
+          export MANIFEST_FILEPATH=./default-image-manifest-$VERSION.manifest
           echo "MANIFEST_FILEPATH=$MANIFEST_FILEPATH" >> $GITHUB_ENV
           go run scripts/create_default_images_manifest.go $MANIFEST_FILEPATH
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -143,6 +143,14 @@ jobs:
           export VERSION=$(cat VERSION)
           make release
 
+      - name: Build default-image manifest file
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
+        run: |
+          export VERSION=$(cat VERSION)
+          export MANIFEST_FILEPATH=./default-image-manifest-$VERSION.txt
+          echo "MANIFEST_FILEPATH=$MANIFEST_FILEPATH" >> $GITHUB_ENV
+          go run scripts/create_default_images_manifest.go $MANIFEST_FILEPATH
+
       - name: Get Version
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
         id: vars
@@ -175,6 +183,18 @@ jobs:
           asset_path: ${{ env.FILE_PATH }}
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: text/yaml
+
+      - name: Upload default-image manifest
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
+        id: upload-astraconnector-yaml
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILE_PATH: ${{ env.MANIFEST_FILEPATH }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.FILE_PATH }}
+          asset_content_type: text/plain
 
       - name: Upload astraconnector_operator.yaml
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}

--- a/scripts/create_default_images_manifest.go
+++ b/scripts/create_default_images_manifest.go
@@ -1,0 +1,50 @@
+/*
+Used in GitHub actions to generate a manifest of default images deployed by connector-operator
+*/
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/NetApp-Polaris/astra-connector-operator/common"
+)
+
+func main() {
+	// Get cmd line args
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run create_default_images_manifest.go <output_file_path>")
+		os.Exit(1)
+	}
+	destinationFilePath := os.Args[1]
+
+	fmt.Printf("Creating default-image manifest file %s\n", destinationFilePath)
+
+	// Gather the full image name and versions
+	defaultImageRegistry := common.DefaultImageRegistry
+	images := []string{
+		fmt.Sprintf("%s/%s", defaultImageRegistry, common.AstraConnectDefaultImage),
+		fmt.Sprintf("%s/%s", defaultImageRegistry, common.NatsSyncClientDefaultImage),
+		fmt.Sprintf("%s/%s", defaultImageRegistry, common.NatsDefaultImage),
+		fmt.Sprintf("%s/%s", defaultImageRegistry, common.NeptuneDefaultImage),
+	}
+
+	// Open the manifest file
+	file, err := os.OpenFile(destinationFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		fmt.Printf("error opening output file for writing: %s\n", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	// Write the file
+	for _, image := range images {
+		// Write the string content to the file
+		_, err = file.WriteString(fmt.Sprintf("%s\n", image))
+		if err != nil {
+			fmt.Printf("error writing to file: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+}


### PR DESCRIPTION
This adds a default-image manifest txt file of the default images used by connector.

The manifest filename is: default-image-manifest-VERSION.manifest
I added "default-" because these images can technically be overridden . 

example contents:
`netappdownloads.jfrog.io/docker-astra-control-staging/arch30/neptune/astra-connector:1.0.202307311828
netappdownloads.jfrog.io/docker-astra-control-staging/arch30/neptune/natssync-client:2.1.202306281610
netappdownloads.jfrog.io/docker-astra-control-staging/arch30/neptune/nats:2.8.4-alpine3.15
netappdownloads.jfrog.io/docker-astra-control-staging/arch30/neptune/neptune:main-b65bdb9-July21`

