### PR TITLE
ASTRACTL-28939 Remove neptune crds and ns from the 23.10 bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,8 +223,6 @@ release: kustomize
 	mkdir build
 	cd details/operator-sdk/config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd details/operator-sdk && $(KUSTOMIZE) build config/default > $(BUILD_DIR)/only_astraconnector_operator.yaml
-	cat $(MAKEFILE_DIR)/details/operator-sdk/config/samples/neptune.yaml > $(BUILD_DIR)/astraconnector_operator.yaml
-	echo "---" >> $(BUILD_DIR)/astraconnector_operator.yaml
 	cat $(BUILD_DIR)/only_astraconnector_operator.yaml >> $(BUILD_DIR)/astraconnector_operator.yaml
 	cp $(MAKEFILE_DIR)/details/operator-sdk/config/samples/astra_v1_astraconnector.yaml $(BUILD_DIR)/astra_v1_astraconnector.yaml
 


### PR DESCRIPTION
Removes neptune crds and namespace from the 23.10 release bundle