### PR TITLE
ASTRACTL-29909:add neptune app label

### DIFF
--- a/app/deployer/neptune/neptuneV2.go
+++ b/app/deployer/neptune/neptuneV2.go
@@ -81,6 +81,7 @@ func (n NeptuneClientDeployerV2) GetDeploymentObjects(m *v1.AstraConnector, ctx 
 				"app.kubernetes.io/name":       "deployment",
 				"app.kubernetes.io/part-of":    "neptune",
 				"control-plane":                "controller-manager",
+				"app":                          "controller.neptune.netapp.io",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{


### PR DESCRIPTION
Add neptune app label that's already [here](https://github.com/NetApp-Polaris/neptune/blob/main/config/manager/manager.yaml#L25) so that label is also there when neptune is deployed by the operator.  At this time, the ASUP trident job is the only one that uses the label.  Similar to trident ASUP code, the Neptune ASUP code finds the controller via an app label.