### PR TITLE
ASTRACTL-29909:move label from deploy to pod

### DIFF
--- a/app/deployer/neptune/neptuneV2.go
+++ b/app/deployer/neptune/neptuneV2.go
@@ -81,7 +81,6 @@ func (n NeptuneClientDeployerV2) GetDeploymentObjects(m *v1.AstraConnector, ctx 
 				"app.kubernetes.io/name":       "deployment",
 				"app.kubernetes.io/part-of":    "neptune",
 				"control-plane":                "controller-manager",
-				"app":                          "controller.neptune.netapp.io",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -98,6 +97,7 @@ func (n NeptuneClientDeployerV2) GetDeploymentObjects(m *v1.AstraConnector, ctx 
 					},
 					Labels: map[string]string{
 						"control-plane": "controller-manager",
+						"app":           "controller.neptune.netapp.io",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Correction from previous PR.  Need the app label on the neptune pod, not the deployment.