### PR TITLE
save cluster ID

### DIFF
--- a/app/register/register.go
+++ b/app/register/register.go
@@ -898,7 +898,7 @@ func (c clusterRegisterUtil) CreateOrUpdateManagedCluster(astraHost, cloudId, cl
 
 		err := c.UpdateManagedCluster(astraHost, clusterId, astraConnectorId, connectorInstalled, apiToken)
 		if err != nil {
-			return ClusterInfo{}, errors.Wrap(err, "error updating managed cluster")
+			return ClusterInfo{ID: clusterId}, errors.Wrap(err, "error updating managed cluster")
 		}
 
 		return ClusterInfo{ID: clusterId, ManagedState: clusterManagedState}, nil
@@ -910,7 +910,7 @@ func (c clusterRegisterUtil) CreateOrUpdateManagedCluster(astraHost, cloudId, cl
 		// Note: we no longer set storageClass for arch3.0 clusters
 		err := c.CreateManagedCluster(astraHost, cloudId, clusterId, "", connectorInstalled, apiToken)
 		if err != nil {
-			return ClusterInfo{}, errors.Wrap(err, "error creating managed cluster")
+			return ClusterInfo{ID: clusterId}, errors.Wrap(err, "error creating managed cluster")
 		}
 
 		return ClusterInfo{ID: clusterId, ManagedState: clusterManagedState}, nil

--- a/app/register/register_test.go
+++ b/app/register/register_test.go
@@ -1297,7 +1297,7 @@ func TestCreateOrUpdateManagedCluster(t *testing.T) {
 
 		clusterInfo, err := clusterRegisterUtil.CreateOrUpdateManagedCluster(host, cloudId, clusterId, connectorId, http.MethodPut, apiToken)
 
-		assert.Equal(t, "", clusterInfo.ID)
+		assert.Equal(t, clusterId, clusterInfo.ID)
 		assert.Equal(t, "", clusterInfo.Name)
 		assert.EqualError(t, err, "error updating managed cluster: error on request put manage clusters: this is an error")
 	})
@@ -1312,7 +1312,7 @@ func TestCreateOrUpdateManagedCluster(t *testing.T) {
 
 		clusterInfo, err := clusterRegisterUtil.CreateOrUpdateManagedCluster(host, cloudId, clusterId, connectorId, http.MethodPut, apiToken)
 
-		assert.Equal(t, "test_clusterId", clusterInfo.ID)
+		assert.Equal(t, clusterId, clusterInfo.ID)
 		assert.Equal(t, "", clusterInfo.Name)
 		assert.Equal(t, "managed", clusterInfo.ManagedState)
 		assert.Nil(t, err)
@@ -1326,7 +1326,7 @@ func TestCreateOrUpdateManagedCluster(t *testing.T) {
 
 		clusterInfo, err := clusterRegisterUtil.CreateOrUpdateManagedCluster(host, cloudId, clusterId, connectorId, http.MethodPost, apiToken)
 
-		assert.Equal(t, "", clusterInfo.ID)
+		assert.Equal(t, clusterId, clusterInfo.ID)
 		assert.Equal(t, "", clusterInfo.Name)
 		assert.EqualError(t, err, "error creating managed cluster: error on request post manage clusters: this is an error")
 	})
@@ -1342,7 +1342,7 @@ func TestCreateOrUpdateManagedCluster(t *testing.T) {
 
 		clusterInfo, err := clusterRegisterUtil.CreateOrUpdateManagedCluster(host, cloudId, clusterId, connectorId, http.MethodPost, apiToken)
 
-		assert.Equal(t, "test_clusterId", clusterInfo.ID)
+		assert.Equal(t, clusterId, clusterInfo.ID)
 		assert.Equal(t, "", clusterInfo.Name)
 		assert.Equal(t, "managed", clusterInfo.ManagedState)
 		assert.Nil(t, err)


### PR DESCRIPTION
We were losing the clusteID (not getting saved in the CR status) if the POST /cluster call succeeded but the managed cluster call failed.

easy fix