### PR TITLE
Revert "ASTRACTL-30644: replace relayV1 with connectorV2 capability"

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -56,9 +56,8 @@ const (
 	AstraPrivateCloudType = "private"
 	AstraPrivateCloudName = "private"
 
-	ConnectorV2Capability      = "connectorV2" // V2 refers specifically to Arch 3.0 connector and beyond
 	ConnectorNeptuneCapability = "neptuneV1"
-	ConnectorRelayCapability   = "relayV1" // TODO ASTRACTL-30644: remove
+	ConnectorRelayCapability   = "relayV1"
 	ConnectorWatcherCapability = "watcherV1"
 
 	AstraClustersAPIVersion        = "1.4"
@@ -71,8 +70,7 @@ func GetNeptuneRepositories() []string {
 
 func GetConnectorCapabilities() []string {
 	capabilities := []string{
-		ConnectorV2Capability,
-		ConnectorRelayCapability, // TODO ASTRACTL-30644: remove
+		ConnectorRelayCapability,
 		ConnectorWatcherCapability,
 	}
 


### PR DESCRIPTION
Reverts NetApp/astra-connector-operator#206

This had unintended consequences when pairing these changes with the current state of the Polaris repo, breaking the entire 3.0 register workflow. Reverting until I can get this stuff fully worked out.