### PR TITLE
Fixed the mixups of podSecurityContext and SecurityContext

### DIFF
--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -256,8 +256,6 @@ func GetSecurityContext() *corev1.SecurityContext {
 
 var pc = corev1.PodSecurityContext{
 	RunAsNonRoot: pointer.Bool(true),
-	RunAsUser:    GetRunAsUser(),
-	RunAsGroup:   GetRunAsGroup(),
 }
 
 func GetPodSecurityContext() *corev1.PodSecurityContext {

--- a/app/conf/config_test.go
+++ b/app/conf/config_test.go
@@ -11,7 +11,6 @@ func TestGetPodSecurityContext(t *testing.T) {
 	sc := conf.GetPodSecurityContext()
 	assert.NotNil(t, sc)
 	assert.True(t, *sc.RunAsNonRoot)
-	assert.NotEqual(t, int64(0), *sc.RunAsUser)
 }
 
 func TestGetSecurityContext(t *testing.T) {


### PR DESCRIPTION
This PR fixed the mixups of PodSecuirtyContext and SecurityContext when sets up astra connector components