### PR TITLE
bump resource timeout

### DIFF
--- a/app/conf/config.go
+++ b/app/conf/config.go
@@ -75,8 +75,8 @@ func DefaultConfiguration() *MutableConfiguration {
 		Port:                    9443,
 		MetricsPort:             8080,
 		HealthProbePort:         8081,
-		WaitDurationForResource: 2 * time.Minute,
-		ErrorTimeout:            2,
+		WaitDurationForResource: 5 * time.Minute,
+		ErrorTimeout:            5,
 		FeatureFlags: featureFlags{
 			DeployNatsConnector:   true,
 			DeployNeptune:         true,

--- a/details/k8s/cluster_type_checker.go
+++ b/details/k8s/cluster_type_checker.go
@@ -172,6 +172,9 @@ func (c *ClusterTypeChecker) isAKSFlavor() bool {
 	aksRoleBinding, err := c.K8sUtil.K8sClientset().RbacV1().ClusterRoles().Get(context.Background(), aksService, metav1.GetOptions{})
 
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return false
+		}
 		c.Log.Error(err, "Unable to get AKS cluster role. Assuming not AKS")
 		return false
 	}


### PR DESCRIPTION
This PR
- bumps resource wait timeout, it takes a bit longer on the ocp clusters running on VMs
- do not log an error for AKS cluster type check if not found