### PR TITLE
ASTRACTL-31541:Add label for ASUP log collection use

### DIFF
--- a/details/operator-sdk/config/manager/manager.yaml
+++ b/details/operator-sdk/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        app: operator.connector.netapp.io
     spec:
       containers:
       - command:


### PR DESCRIPTION
https://jira.ngage.netapp.com/browse/ASTRACTL-31541

There will be a subsequent trident-asup PR for collecting all the logs from the connector operator namespace.  But we don't want to hard code namespaces.  So first adding a label with a key/value that will be the same and present for every connector operator deploy.  The connector ASUP code will use the label to find the operator pod and its namespace.

As expected, operator deployed w/ change has the new label in pod description:

Name:             operator-controller-manager-5b8465778d-g6wtk
Namespace:        astra-connector-operator
Priority:         0
Service Account:  operator-controller-manager
Node:             dev-ol-astra-enterprise-10-wrkr-3/10.193.63.213
Start Time:       Fri, 09 Feb 2024 12:09:01 -0700
Labels:           app=operator.connector.netapp.io   <--------
                  control-plane=controller-manager
                  pod-template-hash=5b8465778d
...