### PR TITLE
remove trailing slash from cloudbridgeurl

### DIFF
--- a/app/register/register.go
+++ b/app/register/register.go
@@ -278,6 +278,7 @@ func GetAstraHostURL(astraConnector *v1.AstraConnector) string {
 	var astraHost string
 	if astraConnector.Spec.NatsSyncClient.CloudBridgeURL != "" {
 		astraHost = astraConnector.Spec.NatsSyncClient.CloudBridgeURL
+		astraHost = strings.TrimSuffix(astraHost, "/")
 	} else {
 		astraHost = common.NatsSyncClientDefaultCloudBridgeURL
 	}

--- a/app/register/register_test.go
+++ b/app/register/register_test.go
@@ -334,6 +334,26 @@ func TestRegisterNatsSyncClient(t *testing.T) {
 	})
 }
 
+func TestGetAstraHostURL(t *testing.T) {
+	t.Run("TestGetAstraHostURLTrailingSlash", func(t *testing.T) {
+		astraConnector := &v1.AstraConnector{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      "test-astra-connector",
+				Namespace: testNamespace,
+			},
+			Spec: v1.AstraConnectorSpec{
+				NatsSyncClient: v1.NatsSyncClient{
+					CloudBridgeURL: "https://netapp.astra.io/",
+				},
+			},
+		}
+
+		host := register.GetAstraHostURL(astraConnector)
+		assert.Equal(t, host, "https://netapp.astra.io")
+
+	})
+}
+
 func TestCloudExists(t *testing.T) {
 	host, cloudId, apiToken := "test_host", "test_cloudId", "test_apiToken"
 


### PR DESCRIPTION
Sanitize input for cloudBridgeURL so that a trailing slash does not cause the application to break.