### PR TITLE
ASTRACTL-31482: fix retries in registration

### DIFF
--- a/app/register/register.go
+++ b/app/register/register.go
@@ -76,7 +76,7 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, body 
 		} else {
 			bodyCopy = bytes.NewReader([]byte{})
 		}
-		_ = bodyCopy
+
 		sleepTimeout := time.Duration(math.Pow(2, float64(i))) * time.Second
 		log.Info(fmt.Sprintf("Retry %d, waiting for %v before next retry\n", i, sleepTimeout))
 

--- a/app/register/register.go
+++ b/app/register/register.go
@@ -62,14 +62,21 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, body 
 	var err error
 	var cancel context.CancelFunc
 
-	bodyBytes, err := io.ReadAll(body)
-	if err != nil {
-		return httpResponse, err, cancel
+	var bodyBytes []byte
+	if body != nil {
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return httpResponse, err, cancel
+		}
 	}
-
 	for i := 0; i < retries; i++ {
-		bodyCopy := bytes.NewBuffer(bodyBytes)
-
+		var bodyCopy *bytes.Reader
+		if body != nil {
+			bodyCopy = bytes.NewReader(bodyBytes)
+		} else {
+			bodyCopy = bytes.NewReader([]byte{})
+		}
+		_ = bodyCopy
 		sleepTimeout := time.Duration(math.Pow(2, float64(i))) * time.Second
 		log.Info(fmt.Sprintf("Retry %d, waiting for %v before next retry\n", i, sleepTimeout))
 

--- a/app/register/register.go
+++ b/app/register/register.go
@@ -62,7 +62,14 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, body 
 	var err error
 	var cancel context.CancelFunc
 
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return httpResponse, err, cancel
+	}
+
 	for i := 0; i < retries; i++ {
+		bodyCopy := bytes.NewBuffer(bodyBytes)
+
 		sleepTimeout := time.Duration(math.Pow(2, float64(i))) * time.Second
 		log.Info(fmt.Sprintf("Retry %d, waiting for %v before next retry\n", i, sleepTimeout))
 
@@ -70,7 +77,7 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, body 
 		var childCtx context.Context
 		childCtx, cancel = context.WithTimeout(ctx, 3*time.Minute)
 
-		req, _ := http.NewRequestWithContext(childCtx, method, url, body)
+		req, _ := http.NewRequestWithContext(childCtx, method, url, bodyCopy)
 
 		req.Header.Add("Content-Type", "application/json")
 


### PR DESCRIPTION
A bug in the retry mechanism led to empty body in successive registration requests. This PR ensures that NewRequestWithContext always gets a valid io.Reader.


https://jira.ngage.netapp.com/browse/ASTRACTL-31482
