### PR TITLE
ASTRACTL-31482: fix registration retries v2

### DIFF
--- a/app/register/register.go
+++ b/app/register/register.go
@@ -63,7 +63,6 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, bodyB
 	var cancel context.CancelFunc
 
 	for i := 0; i < retries; i++ {
-		body := bytes.NewReader(bodyBytes)
 
 		sleepTimeout := time.Duration(math.Pow(2, float64(i))) * time.Second
 		log.Info(fmt.Sprintf("Retry %d, waiting for %v before next retry\n", i, sleepTimeout))
@@ -72,7 +71,7 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, bodyB
 		var childCtx context.Context
 		childCtx, cancel = context.WithTimeout(ctx, 3*time.Minute)
 
-		req, _ := http.NewRequestWithContext(childCtx, method, url, body)
+		req, _ := http.NewRequestWithContext(childCtx, method, url, bytes.NewReader(bodyBytes))
 
 		req.Header.Add("Content-Type", "application/json")
 

--- a/app/register/register.go
+++ b/app/register/register.go
@@ -76,7 +76,7 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, body 
 		} else {
 			bodyCopy = bytes.NewReader([]byte{})
 		}
-		_ = bodyCopy
+
 		sleepTimeout := time.Duration(math.Pow(2, float64(i))) * time.Second
 		log.Info(fmt.Sprintf("Retry %d, waiting for %v before next retry\n", i, sleepTimeout))
 

--- a/app/register/register.go
+++ b/app/register/register.go
@@ -62,20 +62,13 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, body 
 	var err error
 	var cancel context.CancelFunc
 
-	var bodyBytes []byte
-	if body != nil {
-		bodyBytes, err = io.ReadAll(body)
-		if err != nil {
-			return httpResponse, err, cancel
-		}
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return httpResponse, err, cancel
 	}
+
 	for i := 0; i < retries; i++ {
-		var bodyCopy *bytes.Reader
-		if body != nil {
-			bodyCopy = bytes.NewReader(bodyBytes)
-		} else {
-			bodyCopy = bytes.NewReader([]byte{})
-		}
+		bodyCopy := bytes.NewBuffer(bodyBytes)
 
 		sleepTimeout := time.Duration(math.Pow(2, float64(i))) * time.Second
 		log.Info(fmt.Sprintf("Retry %d, waiting for %v before next retry\n", i, sleepTimeout))

--- a/app/register/register.go
+++ b/app/register/register.go
@@ -62,14 +62,21 @@ func DoRequest(ctx context.Context, client HTTPClient, method, url string, body 
 	var err error
 	var cancel context.CancelFunc
 
-	bodyBytes, err := io.ReadAll(body)
-	if err != nil {
-		return httpResponse, err, cancel
+	var bodyBytes []byte
+	if body != nil {
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return httpResponse, err, cancel
+		}
 	}
-
 	for i := 0; i < retries; i++ {
-		bodyCopy := bytes.NewBuffer(bodyBytes)
-
+		var bodyCopy *bytes.Reader
+		if body != nil {
+			bodyCopy = bytes.NewReader(bodyBytes)
+		} else {
+			bodyCopy = bytes.NewReader([]byte{})
+		}
+		_ = bodyCopy
 		sleepTimeout := time.Duration(math.Pow(2, float64(i))) * time.Second
 		log.Info(fmt.Sprintf("Retry %d, waiting for %v before next retry\n", i, sleepTimeout))
 


### PR DESCRIPTION
This removes an redundancy in stream and byte array creation introduced in the previous [PR](https://github.com/NetApp/astra-connector-operator/pull/277) that fixed the retry logic in registration.