### PR TITLE
ASTRACTL-32120: Connector : SPIKE - Explore more efficient options to sending this(Latest Resources) at scale (batching, websockets?)

### DIFF
--- a/app/deployer/connector/astra_connect_natless.go
+++ b/app/deployer/connector/astra_connect_natless.go
@@ -113,6 +113,15 @@ func (d *AstraConnectNatlessDeployer) GetDeploymentObjects(m *v1.AstraConnector,
 								Name:  "SKIP_TLS_VALIDATION",
 								Value: strconv.FormatBool(m.Spec.Astra.SkipTLSValidation),
 							},
+							{
+								Name: "MEMORY_RESOURCE_LIMIT",
+								ValueFrom: &corev1.EnvVarSource{
+									ResourceFieldRef: &corev1.ResourceFieldSelector{
+										ContainerName: common.AstraConnectName,
+										Resource:      "limits.memory",
+									},
+								},
+							},
 						},
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{


### PR DESCRIPTION
closes ASTRACTL-32120
* updates environment in the natless connector deployer to pass in the memory limits set on the container as an env variable.