### PR TITLE
ASTRACTL-32896: revert namespace removal from manager yaml

### DIFF
--- a/cluster-install/neptune.yaml
+++ b/cluster-install/neptune.yaml
@@ -1,16 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: neptune
-    app.kubernetes.io/instance: system
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: namespace
-    app.kubernetes.io/part-of: neptune
-    control-plane: controller-manager
-  name: astra-connector
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/details/operator-sdk/config/manager/manager.yaml
+++ b/details/operator-sdk/config/manager/manager.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This adds the namespace creation back to `manager.yaml`, but removes it from `neptune.yaml` to continue preventing a clash when using the unified installer script.