### PR TITLE
ASTRACTL-32896: fix namespace yaml situation

### DIFF
--- a/cluster-install/kustomization.yaml
+++ b/cluster-install/kustomization.yaml
@@ -3,8 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../details/operator-sdk/config/default
   - ./neptune.yaml
+  - ../details/operator-sdk/config/unified-installer-script
 
 patches:
   - path: ./operator-proxy-role.yaml

--- a/cluster-install/neptune.yaml
+++ b/cluster-install/neptune.yaml
@@ -1,3 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: neptune
+    app.kubernetes.io/instance: system
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/part-of: neptune
+    control-plane: controller-manager
+  name: astra-connector
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/details/operator-sdk/config/default/kustomization.yaml
+++ b/details/operator-sdk/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- ../namespace
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/details/operator-sdk/config/namespace/kustomization.yaml
+++ b/details/operator-sdk/config/namespace/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - namespace.yaml

--- a/details/operator-sdk/config/namespace/namespace.yaml
+++ b/details/operator-sdk/config/namespace/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system

--- a/details/operator-sdk/config/unified-installer-script/kustomization.yaml
+++ b/details/operator-sdk/config/unified-installer-script/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: operator-
+resources:
+  - ../crd
+  - ../rbac
+  - ../manager


### PR DESCRIPTION
This PR does a few things:
- Adds back the namespace resource to `neptune.yaml` to unblock the polaris qual pipeline (would have to wait for a neptune PR to merge otherwise)
- Separates the namespace resource in `details/operator-sdk/config/default/manager.yaml` into its own folder so that it can be excluded from `cluster-install/kustomization.yaml`
- Add a new `details/operator-sdk/config/unified-install-script/kustomization.yaml` that gets pulled in by the cluster-install kustomization file
- Update relevant kustomization files