### PR TITLE
ASTRACTL-33429: Disable leader election and set update strategy to recreate

### DIFF
--- a/app/deployer/neptune/neptuneV2.go
+++ b/app/deployer/neptune/neptuneV2.go
@@ -87,7 +87,9 @@ func (n NeptuneClientDeployerV2) GetDeploymentObjects(m *v1.AstraConnector, ctx 
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
 			Replicas: &neptuneReplicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -166,7 +168,6 @@ func (n NeptuneClientDeployerV2) GetDeploymentObjects(m *v1.AstraConnector, ctx 
 							Args: []string{
 								"--health-probe-bind-address=:8081",
 								"--metrics-bind-address=127.0.0.1:8080",
-								"--leader-elect",
 							},
 							Command: []string{
 								"/manager",

--- a/details/operator-sdk/config/manager/manager.yaml
+++ b/details/operator-sdk/config/manager/manager.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+  strategy:
+    type: Recreate
   replicas: 1
   template:
     metadata:
@@ -21,8 +23,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
We are seeing leader election crashing in scale scenarios. Chatted with @chrisophus and we decided to disable leader election and change the update strategy to address these issues. This makes the changes for both the connector operator and the Neptune controller.

[ASTRACTL-33429](https://jira.ngage.netapp.com/browse/ASTRACTL-33429)
[ASTRACTL-33388](https://jira.ngage.netapp.com/browse/ASTRACTL-33388)
