### PR TITLE
ASTRACTL-32772: pull secret fix

### DIFF
--- a/cluster-install/install.sh
+++ b/cluster-install/install.sh
@@ -2593,11 +2593,10 @@ step_generate_trident_operator_patch() {
         if echo "$_EXISTING_TRIDENT_OPERATOR_PULL_SECRETS" | grep -q "^${IMAGE_PULL_SECRET}$" &> /dev/null; then
             logdebug "image pull secret '$IMAGE_PULL_SECRET' already present in trident-operator"
         else
-            local -r secret_obj='{"name": "'"$IMAGE_PULL_SECRET"'"}'
             if [ -z "$_EXISTING_TRIDENT_OPERATOR_PULL_SECRETS" ]; then
-                patch_list+=',{"op":"replace","path":"/spec/template/spec/imagePullSecrets","value":['"$secret_obj"']}'
+                patch_list+=',{"op":"replace","path":"/spec/template/spec/imagePullSecrets","value":[{"name":"'"$IMAGE_PULL_SECRET"'"}]}'
             else
-                patch_list+=',{"op":"add","path":"/spec/template/spec/imagePullSecrets/-","value":'"$secret_obj"'}'
+                patch_list+=',{"op":"add","path":"/spec/template/spec/imagePullSecrets/-","value":{"name":"'"$IMAGE_PULL_SECRET"'"}}'
             fi
         fi
     fi
@@ -2618,6 +2617,7 @@ step_generate_torc_patch() {
     if [ -z "$torc_name" ]; then fatal "no trident orchestrator name was given"; fi
 
     logheader $__DEBUG "Generating TORC patch"
+
     local torc_patch_list=""
 
     # Trident
@@ -2643,9 +2643,8 @@ step_generate_torc_patch() {
         if echo "$_EXISTING_TORC_PULL_SECRETS" | grep -q "^${IMAGE_PULL_SECRET}$" &> /dev/null; then
             logdebug "image pull secret '$IMAGE_PULL_SECRET' already present in torc"
         else
-            local -r secret_obj='{"name": "'"$IMAGE_PULL_SECRET"'"}'
             if [ -z "$_EXISTING_TRIDENT_OPERATOR_PULL_SECRETS" ]; then
-                torc_patch_list+='{"op":"replace","path":"/spec/imagePullSecrets","value":"'"$IMAGE_PULL_SECRET"'"},'
+                torc_patch_list+='{"op":"replace","path":"/spec/imagePullSecrets","value":["'"$IMAGE_PULL_SECRET"'"]},'
             else
                 torc_patch_list+='{"op":"add","path":"/spec/imagePullSecrets/-","value":"'"$IMAGE_PULL_SECRET"'"},'
             fi

--- a/cluster-install/install.sh
+++ b/cluster-install/install.sh
@@ -17,11 +17,13 @@ _KUBERNETES_VERSION=""
 # existing Trident information (if any) has been collected.
 _TRIDENT_COLLECTION_STEP_CALLED="false"
 _EXISTING_TORC_NAME="" # TORC is short for TridentOrchestrator (works with kubectl too)
+_EXISTING_TORC_PULL_SECRETS="" # Newline-delimited values, e.g. 'secret1\nsecret2\nsecret3'
 _EXISTING_TRIDENT_NAMESPACE=""
 _EXISTING_TRIDENT_IMAGE=""
 _EXISTING_TRIDENT_ACP_ENABLED=""
 _EXISTING_TRIDENT_ACP_IMAGE=""
 _EXISTING_TRIDENT_OPERATOR_IMAGE=""
+_EXISTING_TRIDENT_OPERATOR_PULL_SECRETS="" # Newline-delimited values, e.g. 'secret1\nsecret2\nsecret3'
 _USER_ACCEPTED_TRIDENT_OPERATOR_UPGRADE="" # "true" if yes, "false" if no, "" if the question was never asked
 
 # _PATCHES_ variables contain the k8s patches that will be applied after we've applied all CRs and kustomize resources.
@@ -62,7 +64,7 @@ readonly __COMPONENTS_VALID_VALUES=("$__COMPONENTS_ALL_ASTRA_CONTROL" "$__COMPON
 readonly __DEFAULT_DOCKER_HUB_IMAGE_REGISTRY="docker.io"
 readonly __DEFAULT_DOCKER_HUB_IMAGE_BASE_REPO="netapp"
 readonly __DEFAULT_ASTRA_IMAGE_REGISTRY="cr.astra.netapp.io"
-readonly __DEFAULT_IMAGE_TAG="$__RELEASE_VERSION"
+readonly __DEFAULT_ASTRA_IMAGE_BASE_REPO=""
 
 readonly __DEFAULT_TRIDENT_OPERATOR_IMAGE_NAME="trident-operator"
 readonly __DEFAULT_TRIDENT_AUTOSUPPORT_IMAGE_NAME="trident-autosupport"
@@ -115,10 +117,28 @@ readonly __NEWLINE=$'\n' # This is for readability
 #----------------------------------------------------------------------
 #-- Script config
 #----------------------------------------------------------------------
+process_args() {
+    for arg in "$@"; do
+        case $arg in
+            --help|-h)
+                print_help
+                exit 0
+                ;;
+            --required)
+                local msg="Listed below are all required environment variables which do not have a default value"
+                msg+=" (and so must be provided by the user):${__NEWLINE}"
+                echo "$msg"
+                print_help | grep '\*[A-Z]\+'
+                exit 0
+                ;;
+        esac
+    done
+}
+
 get_configs() {
     # ------------ SCRIPT BEHAVIOR ------------
     CONFIG_FILE="${CONFIG_FILE:-}" # Overrides environment variables specified via command line
-    DRY_RUN="${DRY_RUN:-"true"}" # Skips applying generated resources
+    DRY_RUN="${DRY_RUN:-"false"}" # Skips applying generated resources
     SKIP_IMAGE_CHECK="${SKIP_IMAGE_CHECK:-"false"}" # Skips checking whether images exist or not
     SKIP_ASTRA_CHECK="${SKIP_ASTRA_CHECK:-"false"}" # Skips AC URL, cloud ID, and cluster ID check
     # DISABLE_PROMPTS skips prompting the user when something notable is about to happen (such as a Trident Upgrade).
@@ -196,6 +216,90 @@ get_configs() {
     CONNECTOR_SKIP_TLS_VALIDATION="${CONNECTOR_SKIP_TLS_VALIDATION:-"${SKIP_TLS_VALIDATION:-"false"}"}"
     CONNECTOR_AUTOSUPPORT_ENROLLED="${CONNECTOR_AUTOSUPPORT_ENROLLED:-"false"}"
     CONNECTOR_AUTOSUPPORT_URL="${CONNECTOR_AUTOSUPPORT_URL:-$__PRODUCTION_AUTOSUPPORT_URL}"
+}
+
+print_help() {
+    cat <<EOF
+Here is a list of available options and environment variables for configuring the Astra cluster installation script.
+Values which are required and have no default value are marked with '*'.
+
+Options:
+  --help/-h    Show this message and exit.
+  --required   Prints all required environment variables which do not have a default value.
+
+Environment Variables:
+  ----- Script Functionality
+  CONFIG_FILE                        Path to a configuration file. Overrides environment variables specified via command line.
+  DRY_RUN                            Skips applying generated resources when set to true. Default is false.
+  SKIP_IMAGE_CHECK                   Skips checking if images exist when set to true. Default is false.
+  SKIP_ASTRA_CHECK                   Skips all checks requiring a connection to Astra Control when set to true. Default is false.
+  SKIP_TLS_VALIDATION                Skips TLS validation for all requests to Astra Control, including the Connector (unless CONNECTOR_SKIP_TLS_VALIDATION is set) when set to true. Default is false.
+  DISABLE_PROMPTS                    Skips all prompts, answering 'yes' by default when set to true. Default is false.
+  DO_NOT_MODIFY_EXISTING_TRIDENT     Prevents any and all modification to the existing Trident installation (if any). Required if DISABLE_PROMPTS is true, otherwise defaults to false.
+
+  ----- General Configuration
+  *KUBECONFIG                        Path to the KUBECONFIG for the cluster you'd like to manage. Required.
+  COMPONENTS                         Determines what will be installed/upgraded. Default is ALL_ASTRA_CONTROL.
+  IMAGE_PULL_SECRET                  Image pull secret for the Docker registry.
+  NAMESPACE                          Overrides EVERY resource's namespace (for fresh installs only, not upgrades).
+  LABELS                             Labels to be added to the generated resources (disclaimer: does not apply labels to resources created by the operators).
+  RESOURCE_LIMITS_PRESET             Resource limit preset to use. Overridden by RESOURCE_LIMITS_CUSTOM_CPU and RESOURCE_LIMITS_CUSTOM_MEMORY (disclaimer: resource limits not currently supported by Trident).
+  RESOURCE_LIMITS_CUSTOM_CPU         Custom CPU resource limit. Plain number.
+  RESOURCE_LIMITS_CUSTOM_MEMORY      Custom Memory resource limit (in 'Gi')'. Plain number (i.e. do not include the 'Gi').
+
+  ----- Image Configuration
+    Image configuration is separated into three distinct parts:
+      - Registry ("private.registry.io")
+      - Repository ("some/repository/path/trident")
+      - Tag ("24.02")
+
+    Given the following images :
+      - Trident Operator:    private.registry.io/some/repository/path/trident-operator:24.02
+      - Trident Autosupport: private.registry.io/some/repository/path/trident-autosupport:24.02
+      - Trident:             private.registry.io/some/repository/path/trident:24.02
+      - Trident ACP:         private.registry.io/some/repository/path/trident-acp:24.02
+      - Connector Operator:  private.registry.io/some/repository/path/astra-connector-operator:202405211614-main
+
+    An appropriate configuration might be:
+      - IMAGE_REGISTRY="private.registry.io"
+      - IMAGE_BASE_REPO="some/repository/path"
+      - TRIDENT_IMAGE_TAG="24.02"
+      - CONNECTOR_OPERATOR_IMAGE_TAG="202405211614-main"
+
+  IMAGE_REGISTRY                     The default Docker registry to pull all images from. Overridden by values below.
+  TRIDENT_OPERATOR_IMAGE_REGISTRY    The Docker registry to pull the Trident Operator image from.
+  TRIDENT_AUTOSUPPORT_IMAGE_REGISTRY The Docker registry to pull the Trident Autosupport image from.
+  TRIDENT_IMAGE_REGISTRY             The Docker registry to pull the Trident image from.
+  CONNECTOR_OPERATOR_IMAGE_REGISTRY  The Docker registry to pull the Connector Operator image from.
+  CONNECTOR_IMAGE_REGISTRY           The Docker registry to pull the Connector image from.
+  NEPTUNE_IMAGE_REGISTRY             The Docker registry to pull the Neptune image from.
+  TRIDENT_ACP_IMAGE_REGISTRY         The Docker registry to pull the Trident ACP image from.
+
+  IMAGE_BASE_REPO                    The default base repository path (i.e. excluding the image name) for all images. Overridden by values below.
+  TRIDENT_OPERATOR_IMAGE_REPO        The repository path for the Trident Operator image.
+  TRIDENT_AUTOSUPPORT_IMAGE_REPO     The repository path for the Trident Autosupport image.
+  TRIDENT_IMAGE_REPO                 The repository path for the Trident image.
+  CONNECTOR_OPERATOR_IMAGE_REPO      The repository path for the Connector Operator image.
+  CONNECTOR_IMAGE_REPO               The repository path for the Connector image.
+  NEPTUNE_IMAGE_REPO                 The repository path for the Neptune image.
+  TRIDENT_ACP_IMAGE_REPO             The repository path for the Trident ACP image.
+
+  TRIDENT_IMAGE_TAG                  The tag for the Trident image. Overridden by other 'TRIDENT_' values below.
+  TRIDENT_OPERATOR_IMAGE_TAG         The tag for the Trident Operator image.
+  TRIDENT_AUTOSUPPORT_IMAGE_TAG      The tag for the Trident Autosupport image.
+  TRIDENT_ACP_IMAGE_TAG              The tag for the Trident ACP image.
+  CONNECTOR_OPERATOR_IMAGE_TAG       The tag for the Connector Operator image.
+
+  ----- Connector Configuration
+  *ASTRA_CONTROL_URL                 The Astra Control URL. Required, provided by the Astra Control UI.
+  *ASTRA_API_TOKEN                   The Astra API token. Required, provided by the Astra Control UI.
+  *ASTRA_ACCOUNT_ID                  The Astra account ID. Required, provided by the Astra Control UI.
+  *ASTRA_CLOUD_ID                    The Astra cloud ID. Required, provided by the Astra Control UI.
+  *ASTRA_CLUSTER_ID                  The Astra cluster ID. Required, provided by the Astra Control UI.
+  CONNECTOR_HOST_ALIAS_IP            Sets a host alias for the Astra Connector pod.
+  CONNECTOR_SKIP_TLS_VALIDATION      (WARNING: Not for production use!) Skips TLS validation for the Connector's requests to Astra Control if set to true.
+  CONNECTOR_AUTOSUPPORT_ENROLLED     Enrolls the Connector in autosupport if set to true. Default is false.
+EOF
 }
 
 set_log_level() {
@@ -369,6 +473,17 @@ get_config_acp_image() {
     as_full_image "$TRIDENT_ACP_IMAGE_REGISTRY" "$TRIDENT_ACP_IMAGE_REPO" "$TRIDENT_ACP_IMAGE_TAG"
 }
 
+get_config_connector_operator_image() {
+    as_full_image "$CONNECTOR_OPERATOR_IMAGE_REGISTRY" "$CONNECTOR_OPERATOR_IMAGE_REPO" "$CONNECTOR_OPERATOR_IMAGE_TAG"
+}
+
+get_config_connector_image() {
+    as_full_image "$CONNECTOR_IMAGE_REGISTRY" "$CONNECTOR_IMAGE_REPO" "$CONNECTOR_IMAGE_TAG"
+}
+
+get_config_neptune_image() {
+    as_full_image "$NEPTUNE_IMAGE_REGISTRY" "$NEPTUNE_IMAGE_REPO" "$NEPTUNE_IMAGE_TAG"
+}
 
 trident_image_needs_upgraded() {
     local -r configured_image="$(get_config_trident_image)"
@@ -405,6 +520,27 @@ acp_image_needs_upgraded() {
 acp_is_enabled() {
     logdebug "Checking if ACP is enabled: '$_EXISTING_TRIDENT_ACP_ENABLED'"
     [ "$_EXISTING_TRIDENT_ACP_ENABLED" == "true" ] && return 0
+    return 1
+}
+
+config_has_at_least_one_custom_registry_or_repo() {
+    local -r docker_hub_default="$(join_rpath "$__DEFAULT_DOCKER_HUB_IMAGE_REGISTRY" "$__DEFAULT_DOCKER_HUB_IMAGE_BASE_REPO")"
+    local -r astra_reg_default="$(join_rpath "$__DEFAULT_ASTRA_IMAGE_REGISTRY" "$__DEFAULT_ASTRA_IMAGE_BASE_REPO")"
+
+    if components_include_trident || components_include_acp; then
+        get_config_trident_operator_image | starts_with "$docker_hub_default" || return 0
+        get_config_trident_autosupport_image | starts_with "$docker_hub_default" || return 0
+        get_config_trident_image | starts_with "$docker_hub_default" || return 0
+    fi
+    if components_include_acp; then
+        get_config_acp_image | starts_with "$astra_reg_default" || return 0
+    fi
+    if components_include_connector; then
+        get_config_connector_operator_image | starts_with "$docker_hub_default" || return 0
+        get_config_connector_image | starts_with "$astra_reg_default" || return 0
+        get_config_neptune_image | starts_with "$astra_reg_default" || return 0
+    fi
+
     return 1
 }
 
@@ -789,6 +925,24 @@ join_rpath() {
     done
 
     echo "$joined"
+}
+
+# starts_with checks if a string starts with the given substring.
+# Usage: `echo "abc" | starts_with "ab"` returns 0 (true).
+starts_with() {
+    local str_to_check="" && read -r str_to_check
+    local -r substring="$1"
+
+    [ -z "$str_to_check" ] && fatal "no str_to_check given"
+    [ -z "$substring" ] && fatal "no substring given"
+
+    case $str_to_check in
+        "$substring"*)
+            return 0
+            ;;
+    esac
+
+    return 1
 }
 
 str_contains_at_least_one() {
@@ -1240,7 +1394,7 @@ k8s_get_resource() {
     fi
 
     local base_msg="A failure occurred when checking if resource '$resource'"
-    [ -n "$namespace" ] base_msg+=" (namespace: $namespace)"
+    [ -n "$namespace" ] && base_msg+=" (namespace: $namespace)"
     base_msg+=" exists"
     if echo "$captured_err" | grep -q "NotFound" &> /dev/null; then
         logdebug "got NotFound error for resource '$resource', letting it through" >& 2
@@ -1307,7 +1461,7 @@ wait_for_deployment_running() {
     local -r sleep_time="5" # Seconds
     local -r max_checks="$(( (timeout * 60) / sleep_time ))"
     local counter=0
-    loginfo "Waiting on deployment/$deployment (timeout: $timeout)..."
+    loginfo "Waiting on deployment/$deployment (timeout: ${timeout}m)..."
     while ((counter < max_checks)); do
         if kubectl rollout status -n "$namespace" "deploy/$deployment" -w=false &> /dev/null; then
             logdebug "deploy/$deployment is now running"
@@ -1332,6 +1486,8 @@ wait_for_cr_state() {
     [ -z "$path" ] && fatal "no JSON path given"
     [ -z "$desired_state" ] && fatal "no desired state given"
 
+    loginfo "Waiting on $resource -> $path to reach '$desired_state' (timeout: ${timeout}m)..."
+
     local -r sleep_time="5" # Seconds
     local -r max_checks="$(( (timeout * 60) / sleep_time ))"
     local counter=0
@@ -1355,7 +1511,7 @@ wait_for_cr_state() {
 wait_for_resource_created() {
     local -r resource="$1"
     local -r namespace="$2"
-    local -r timeout="${3:-60}"
+    local -r timeout="${3:-120}"
 
     [ -z "$resource" ] && fatal "no resource given"
     [ -z "$namespace" ] && fatal "no namespace given"
@@ -1599,8 +1755,17 @@ step_check_config() {
         if [ -z "$NAMESPACE" ]; then
             prompt_user "NAMESPACE" "NAMESPACE is required when specifying an IMAGE_PULL_SECRET. Please enter the namespace:"
         fi
-        add_to_config_builder "IMAGE_PULL_SECRET"
+    elif config_has_at_least_one_custom_registry_or_repo; then
+        local custom_reg_warning="We detected one or more custom registry or repo values"
+        custom_reg_warning+=", but no IMAGE_PULL_SECRET was specified. If any of your images are hosted in a private"
+        custom_reg_warning+=" registry, an image pull secret will need to be created and IMAGE_PULL_SECRET set."
+        if prompts_disabled; then
+            logwarn "$custom_reg_warning"
+        elif prompt_user_yes_no "$custom_reg_warning${__NEWLINE}Would you like to specify a pull secret now?"; then
+            prompt_user "IMAGE_PULL_SECRET" "Enter a value for IMAGE_PULL_SECRET: "
+        fi
     fi
+    add_to_config_builder "IMAGE_PULL_SECRET"
     add_to_config_builder "NAMESPACE"
 
     if prompts_disabled; then
@@ -1670,12 +1835,18 @@ step_check_k8s_version_in_range() {
 
     logheader $__DEBUG "Checking if Kubernetes version is within range ($minimum <=> $maximum)..."
 
-    local current; current="$(kubectl version -o json | jq -r '.serverVersion.gitVersion')"
+    local current; current="$(kubectl version -o json 2> "$__ERR_FILE" | jq -r '.serverVersion.gitVersion' 2> /dev/null)"
+    local -r captured_err="$(get_captured_err)"
+    if [ -z "$current" ] || [ "$current" == null ] || [ -n "$captured_err" ]; then
+        add_problem "Failed to get your cluster's Kubernetes version: $captured_err"
+        return 1
+    fi
+
     current=${current#v}
     _KUBERNETES_VERSION="$current"
     # TODO: differentiate between a connection/timeout failure and an actual version failure
     if ! version_in_range "$current" "$minimum" "$maximum"; then
-        add_problem "k8s version '$current': not within range ($minimum-$maximum)"
+        add_problem "Your cluster's Kubernetes version '$current' is not within the supported range ($minimum-$maximum)"
     else
         logdebug "k8s version '$current': OK"
     fi
@@ -1688,12 +1859,19 @@ step_check_k8s_permissions() {
         logheader $__DEBUG "kubectl is not installed, skipping k8s permission check"
     fi
 
-    # TODO ASTRACTL-32772: differentiate between a connection/timeout failure and an actual permission failure
-    if [ "$(kubectl auth can-i '*' '*' --all-namespaces)" = "yes" ]; then
+    local -r has_permission="$(kubectl auth can-i '*' '*' --all-namespaces 2> "$__ERR_FILE")"
+    local -r captured_err="$(get_captured_err)"
+    if [ "$has_permission" == "yes" ]; then
         logdebug "k8s permissions: OK"
+        return 0
+    elif [ "$has_permission" != "yes" ]; then
+        add_problem "Kubernetes user does not have admin privileges"
+    elif [ -n "$captured_err" ]; then
+        add_problem "Failed to check if Kubernetes user has admin privilege: $captured_err"
     else
-        add_problem "k8s permissions: user does not have admin privileges" "Kubernetes user does not have admin privileges"
+        add_problem "Failed to check if Kubernetes user has admin privilege: unknown error"
     fi
+
 }
 
 step_check_volumesnapshotclasses() {
@@ -1708,22 +1886,48 @@ step_check_volumesnapshotclasses() {
     fi
 }
 
-step_check_namespace_exists() {
-    if [ -z "$(kubectl get namespace "$NAMESPACE" -o name 2> /dev/null)" ]; then
-        if [ -n "$IMAGE_PULL_SECRET" ]; then
-            local err_msg="The specified namespace '$NAMESPACE' does not exist on the cluster, but IMAGE_PULL_SECRET is set."
-            err_msg+=" Please create the namespace and secret, or unset IMAGE_PULL_SECRET."
-            add_problem "namespace '$NAMESPACE': not found but IMAGE_PULL_SECRET is set" "$err_msg"
+step_check_namespace_and_pull_secret_exist() {
+    local -r namespace="$NAMESPACE"
+    local -r pull_secret="$IMAGE_PULL_SECRET"
+    local err_msg=""
+
+    [ -z "$namespace" ] && return 0
+
+    # Best effort guess at which registry to put in the create command
+    local registry="<REGISTRY>"
+    if components_include_connector; then
+        registry="$CONNECTOR_IMAGE_REGISTRY"
+    # Skip if Trident's image is still set to our default of 'docker.io/netapp', which is public
+    elif components_include_trident && ! str_contains_at_least_one "$(get_config_trident_image)" "docker.io/netapp" ; then
+        registry="$TRIDENT_IMAGE_REGISTRY"
+    elif components_include_acp; then
+        registry="$TRIDENT_ACP_IMAGE_REGISTRY"
+    fi
+
+    local create_secret_cmd="kubectl create secret docker-registry '$pull_secret' -n '$namespace'"
+    create_secret_cmd+=" --docker-server='$registry' --docker-username='<USERNAME>' --docker-password='<PASSWORD>'"
+
+    if ! k8s_resource_exists "namespace/$namespace"; then
+        if [ -n "$pull_secret" ]; then
+            err_msg="The specified NAMESPACE '$namespace' does not exist on the cluster, but IMAGE_PULL_SECRET is set."
+            err_msg+=" Please create the namespace and secret:"
+            err_msg+="${__NEWLINE}    - kubectl create namespace '$namespace'"
+            err_msg+="${__NEWLINE}    - $create_secret_cmd"
+            add_problem "namespace '$namespace': not found but IMAGE_PULL_SECRET is set" "$err_msg"
             exit_if_problems
         fi
-        if prompt_user_yes_no "The namespace $NAMESPACE doesn't exist. Create it now? Choosing 'no' will exit"; then
-            kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-            logdebug "namespace '$NAMESPACE': OK"
+        if prompt_user_yes_no "The namespace $namespace doesn't exist. Create it now? Choosing 'no' will exit"; then
+            kubectl create namespace "$namespace" --dry-run=client -o yaml | kubectl apply -f -
+            logdebug "namespace '$namespace': OK"
         else
-            local -r err_msg="User chose not to create the namespace. Please create the namespace and/or run the script again."
+            err_msg="User chose not to create the namespace. Please create the namespace and/or run the script again."
             add_problem "User chose not to create the namespace. Exiting." "$err_msg"
             exit_if_problems
         fi
+    elif [ -n "$pull_secret" ] && ! k8s_resource_exists "secret/$pull_secret" "$namespace"; then
+        err_msg="The specified IMAGE_PULL_SECRET '$pull_secret' does not exist in namespace '$namespace'."
+        err_msg+=" Please create it:${__NEWLINE}    - $create_secret_cmd"
+        add_problem "pull secret '$pull_secret' not found in namespace '$namespace'" "$err_msg"
     fi
 }
 
@@ -2067,6 +2271,27 @@ EOF
     logdebug "$kustomization_file: added namespace transformer ($transformer_file_name)"
 }
 
+step_kustomize_global_pull_secret_if_needed() {
+    local -r global_pull_secret="${1:-""}"
+    local -r kustomization_file="${2}"
+    local -r kustomization_dir="$(dirname "$kustomization_file")"
+    [ -z "$global_pull_secret" ] && return 0
+
+    [ -z "$kustomization_file" ] && fatal "no kustomization file given"
+    [ ! -f "$kustomization_file" ] && fatal "kustomization file '$kustomization_file' does not exist"
+
+    insert_into_file_after_pattern "$kustomization_file" "patches:" '
+- target:
+    kind: Deployment
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/imagePullSecrets
+      value:
+        - name: "'"${global_pull_secret}"'"
+'
+    logdebug "$kustomization_file: added pull secret patch ($global_pull_secret)"
+}
+
 step_generate_astra_connector_yaml() {
     local -r kustomization_file="$__GENERATED_KUSTOMIZATION_FILE"
     local -r kustomization_dir="$(dirname "$kustomization_file")"
@@ -2262,6 +2487,15 @@ step_collect_existing_trident_info() {
         logdebug "trident ACP image: not found"
     fi
 
+    # TORC imagePullSecrets
+    local -r torc_pull_secrets="$(echo "$torc_json" | jq -r '.spec.imagePullSecrets | join("\n")' 2> /dev/null)"
+    if [ -n "$torc_pull_secrets" ] && [ "$torc_pull_secrets" != "null" ]; then
+        logdebug "torc pull secrets:${__NEWLINE}$torc_pull_secrets"
+        _EXISTING_TORC_PULL_SECRETS="$torc_pull_secrets"
+    else
+        logdebug "torc pull secrets: not found"
+    fi
+
     # Trident operator
     local -r trident_operator_json="$(k8s_get_resource "deploy/trident-operator" "$trident_ns" "json")"
     if [ -n "$trident_operator_json" ]; then
@@ -2278,6 +2512,14 @@ step_collect_existing_trident_info() {
         fi
     else
         logdebug "trident operator: not found"
+    fi
+    
+    local -r op_pull_secrets="$(echo "$trident_operator_json" | jq -r '[.spec.template.spec.imagePullSecrets.[] | .name] | join("\n")' 2> /dev/null)"
+    if [ -n "$op_pull_secrets" ] && [ "$op_pull_secrets" != "null" ]; then
+        logdebug "trident operator pull secrets:${__NEWLINE}$op_pull_secrets"
+        _EXISTING_TRIDENT_OPERATOR_PULL_SECRETS="$op_pull_secrets"
+    else
+        logdebug "trident operator pull secrets: not found"
     fi
 }
 
@@ -2343,8 +2585,28 @@ step_generate_trident_operator_patch() {
     [ -z "$new_image" ] && fatal "no trident operator image found"
 
     logheader $__DEBUG "Generating Trident Operator patch"
-    local -r patch='[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"'"$new_image"'"}]'
-    _PATCHES_TRIDENT_OPERATOR+=("deploy/trident-operator -n '$namespace' --type=json -p '$(echo "$patch" | jq '.')'")
+    local -r image_patch='{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"'"$new_image"'"}'
+    local -a patch_list="$image_patch"
+
+    # Update image pull secrets if needed
+    if [ -n "$IMAGE_PULL_SECRET" ]; then
+        if echo "$_EXISTING_TRIDENT_OPERATOR_PULL_SECRETS" | grep -q "^${IMAGE_PULL_SECRET}$" &> /dev/null; then
+            logdebug "image pull secret '$IMAGE_PULL_SECRET' already present in trident-operator"
+        else
+            local -r secret_obj='{"name": "'"$IMAGE_PULL_SECRET"'"}'
+            if [ -z "$_EXISTING_TRIDENT_OPERATOR_PULL_SECRETS" ]; then
+                patch_list+=',{"op":"replace","path":"/spec/template/spec/imagePullSecrets","value":['"$secret_obj"']}'
+            else
+                patch_list+=',{"op":"add","path":"/spec/template/spec/imagePullSecrets/-","value":'"$secret_obj"'}'
+            fi
+        fi
+    fi
+
+    if [ -n "$patch_list" ]; then
+        echo "[${patch_list%,}]"
+        patch_list="'$(echo "[${patch_list%,}]" | jq '.')'"
+        _PATCHES_TRIDENT_OPERATOR+=("deploy/trident-operator -n '$namespace' --type=json -p $patch_list")
+    fi
 }
 
 step_generate_torc_patch() {
@@ -2376,7 +2638,21 @@ step_generate_torc_patch() {
         torc_patch_list+='{"op":"replace","path":"/spec/autosupportImage","value":"'"$autosupport_image"'"},'
     fi
 
-    if [ "${#torc_patch_list[@]}" -gt 0 ]; then
+    # Update image pull secrets if needed
+    if [ -n "$IMAGE_PULL_SECRET" ]; then
+        if echo "$_EXISTING_TORC_PULL_SECRETS" | grep -q "^${IMAGE_PULL_SECRET}$" &> /dev/null; then
+            logdebug "image pull secret '$IMAGE_PULL_SECRET' already present in torc"
+        else
+            local -r secret_obj='{"name": "'"$IMAGE_PULL_SECRET"'"}'
+            if [ -z "$_EXISTING_TRIDENT_OPERATOR_PULL_SECRETS" ]; then
+                torc_patch_list+='{"op":"replace","path":"/spec/imagePullSecrets","value":"'"$IMAGE_PULL_SECRET"'"},'
+            else
+                torc_patch_list+='{"op":"add","path":"/spec/imagePullSecrets/-","value":"'"$IMAGE_PULL_SECRET"'"},'
+            fi
+        fi
+    fi
+
+    if [ -n "$torc_patch_list" ]; then
         torc_patch_list="'$(echo "[${torc_patch_list%,}]" | jq '.')'"
         _PATCHES_TORC+=("tridentorchestrator $torc_name --type=json -p ${torc_patch_list}")
     fi
@@ -2393,7 +2669,7 @@ step_add_labels_to_kustomization() {
     logheader $__DEBUG "Adding labels to kustomization and crs file"
 
     local -r content="labels:${__NEWLINE}- pairs:${__NEWLINE}${processed_labels}"
-    insert_into_file_after_pattern "${kustomization_file}" "kind:" "${content}"
+    insert_into_file_after_pattern "${kustomization_file}" "kind: Kustomization" "${content}"
 
     logdebug "kustomization labels: OK"
 }
@@ -2432,17 +2708,31 @@ step_apply_resources() {
     # Apply operator resources
     logdebug "apply operator resources"
     local output=""
+    local captured_err=""
     if ! is_dry_run; then
-        output="$(kubectl apply -k "$operators_dir" 2>&1)"
+        output="$(kubectl apply -k "$operators_dir" 2> "$__ERR_FILE")"
+        captured_err="$(get_captured_err)"
+        if echo "$captured_err" | grep -q "Warning:"; then
+            logdebug "captured warning when applying kustomize resources:${__NEWLINE}$captured_err"
+        elif echo "$captured_err" | grep -q "no objects passed to apply"; then
+            logdebug "no kustomize resources to apply, skipping"
+        elif [ -z "$output" ] || [ -n "$captured_err" ]; then
+            add_problem "Failed to apply kustomize resources: $captured_err"
+        fi
         logdebug "kustomize apply output:${__NEWLINE}$output"
     fi
+    exit_if_problems
     loginfo "* Astra operators have been applied to the cluster."
 
     # Apply CRs (if we have any)
     if [ -f "$crs_file_path" ]; then
         logdebug "apply CRs"
         if ! is_dry_run; then
-            output="$(kubectl apply -f "$crs_file_path")"
+            output="$(kubectl apply -f "$crs_file_path" 2> "$__ERR_FILE")"
+            captured_err="$(get_captured_err)"
+            if [ -z "$output" ] || [ -n "$captured_err" ]; then
+                add_problem "Failed to apply CRs: $captured_err"
+            fi
             logdebug "$output"
         else
             logdebug "skipped due to dry run"
@@ -2451,6 +2741,7 @@ step_apply_resources() {
     else
         logdebug "No CRs file to apply"
     fi
+    exit_if_problems
 }
 
 step_apply_trident_operator_patches() {
@@ -2520,6 +2811,7 @@ step_generate_and_apply_resource_limit_patches() {
     local -r patch_path="resources"
     local -r patch_value="$_PROCESSED_RESOURCE_LIMITS"
     local -a patches_list_for_debugging=()
+    local err_msg=""
 
     logheader "$__INFO" "$(prefix_dryrun "Applying resource limits (this may take a few minutes)...")"
     logdebug "configured limits: $patch_value"
@@ -2641,6 +2933,7 @@ step_cleanup_tmp_files() {
 #======================================================================
 #== Main
 #======================================================================
+process_args "$@"
 set_log_level
 logln $__INFO "====== Astra Cluster Installer ${__RELEASE_VERSION} ======"
 load_config_from_file_if_given "$CONFIG_FILE"
@@ -2666,7 +2959,10 @@ exit_if_problems
 step_check_volumesnapshotclasses
 
 # REGISTRY access
-if [ -n "$NAMESPACE" ]; then step_check_namespace_exists; fi
+if [ -n "$NAMESPACE" ]; then
+    step_check_namespace_and_pull_secret_exist
+    exit_if_problems
+fi
 if [ "$SKIP_IMAGE_CHECK" != "true" ]; then
     step_check_all_images_can_be_pulled
 else
@@ -2688,6 +2984,7 @@ step_check_kubeconfig_choice
 step_determine_resource_limit_preset
 step_init_generated_dirs_and_files
 step_kustomize_global_namespace_if_needed "$NAMESPACE" "$__GENERATED_KUSTOMIZATION_FILE"
+step_kustomize_global_pull_secret_if_needed "$IMAGE_PULL_SECRET" "$__GENERATED_KUSTOMIZATION_FILE"
 
 # CONNECTOR yaml
 if components_include_connector; then

--- a/cluster-install/install.sh
+++ b/cluster-install/install.sh
@@ -2811,7 +2811,6 @@ step_generate_and_apply_resource_limit_patches() {
     local -r patch_path="resources"
     local -r patch_value="$_PROCESSED_RESOURCE_LIMITS"
     local -a patches_list_for_debugging=()
-    local err_msg=""
 
     logheader "$__INFO" "$(prefix_dryrun "Applying resource limits (this may take a few minutes)...")"
     logdebug "configured limits: $patch_value"

--- a/cluster-install/install.sh
+++ b/cluster-install/install.sh
@@ -2934,7 +2934,7 @@ step_cleanup_tmp_files() {
 #======================================================================
 process_args "$@"
 set_log_level
-logln $__INFO "====== Astra Cluster Installer ${__RELEASE_VERSION} ======"
+logln $__INFO "====== Astra Unified Installer ${__RELEASE_VERSION} ======"
 load_config_from_file_if_given "$CONFIG_FILE"
 exit_if_problems
 


### PR DESCRIPTION
- Add help message and arg processing
- Add `IMAGE_PULL_SECRET` to `trident-operator` and/or `torc` during upgrades if they're missing from the list
- Add prompt/warning if `IMAGE_PULL_SECRET=""` and the user is using custom images

Tested these changes through 4 scenarios:
1. Greenfield (no initial connector/trident install)
2. Brownfield (no initial connector, but pre-existing trident at 23.07)
3. Brownfield, but DO_NOT_MODIFY_EXISTING_TRIDENT=true (same setup as 2nd test)
4. Greenfield at version 23.07 + modified pull secrets + rerun script with upgrade to verify that pull secrets are properly added