### PR TITLE
astractl-33663: scale memory limits based on snpahot/backup count

### DIFF
--- a/unified-installer/astra-unified-installer.sh
+++ b/unified-installer/astra-unified-installer.sh
@@ -1855,7 +1855,7 @@ step_generate_astra_connector_yaml() {
     memory_limit=2
     if [  "$DISABLE_PROMPTS" != "true" ]; then
       if prompt_user_yes_no "Do you anticipate having more than 10,000 snapshots and backups existing at the same time at any point? "; then
-          snapshot_count="" # Default snapshot count
+          local snapshot_count="" # Default snapshot count
           prompt_user_number_greater_than_zero snapshot_count "Please estimate the maximum number of snapshots and backups you expect to have existing simultaneously within this cluster? (enter number value): "
           # Calculate estimated_memory and round up to the nearest integer
 

--- a/unified-installer/astra-unified-installer.sh
+++ b/unified-installer/astra-unified-installer.sh
@@ -1860,9 +1860,7 @@ step_generate_astra_connector_yaml() {
         # that our guidance is to increase the memory 1GB for every 5k snapshots/backups beyond our 10k default
         if [ $snapshot_count -ge 15000 ]; then
           additional_snapshots=$(echo "$snapshot_count 10000" | awk '{printf("%d\n", $1-$2)}')
-          echo "DEBUG, additional_snapshots=${additional_snapshots}"
           estimated_memory=$(echo "$additional_snapshots 5000" | awk '{printf("%d\n", ($1/$2)+2)}')
-          echo "DEBUG, estimated_memory=${estimated_memory}"
         else
           estimated_memory=2
         fi

--- a/unified-installer/astra-unified-installer.sh
+++ b/unified-installer/astra-unified-installer.sh
@@ -609,7 +609,7 @@ prompt_user_yes_no() {
     local prompt=$1
     local result
     if [ -z "$prompt" ]; then fatal "no prompt message was given"; fi
-    if [ "$DISABLE_PROMPTS" == "true" ]; then return 1; fi
+    if [ "$DISABLE_PROMPTS" == "true" ]; then return 0; fi
 
     echo
     while true; do
@@ -1853,19 +1853,21 @@ step_generate_astra_connector_yaml() {
 
     # Default memory limit
     memory_limit=2
-    if prompt_user_yes_no "Do you anticipate having more than 10,000 snapshots and backups existing at the same time at any point? "; then
-        snapshot_count="" # Default snapshot count
-        prompt_user_number_greater_than_zero snapshot_count "Please estimate the maximum number of snapshots and backups you expect to have existing simultaneously within this cluster? (enter number value): "
-        # Calculate estimated_memory and round up to the nearest integer
+    if [  "$DISABLE_PROMPTS" != "true" ]; then
+      if prompt_user_yes_no "Do you anticipate having more than 10,000 snapshots and backups existing at the same time at any point? "; then
+          snapshot_count="" # Default snapshot count
+          prompt_user_number_greater_than_zero snapshot_count "Please estimate the maximum number of snapshots and backups you expect to have existing simultaneously within this cluster? (enter number value): "
+          # Calculate estimated_memory and round up to the nearest integer
 
-        # Our default value of 2GB is sufficient to handle 10k snapshots/backups. If a customer intends to scale beyond
-        # that our guidance is to increase the memory 1GB for every 5k snapshots/backups beyond our 10k default
-        estimated_memory=$(echo "$snapshot_count 5000" | awk '{printf("%d\n", $1/$2)}')
+          # Our default value of 2GB is sufficient to handle 10k snapshots/backups. If a customer intends to scale beyond
+          # that our guidance is to increase the memory 1GB for every 5k snapshots/backups beyond our 10k default
+          estimated_memory=$(echo "$snapshot_count 5000" | awk '{printf("%d\n", $1/$2)}')
 
-        # If estimated_memory is greater than memory_limit, set memory_limit to estimated_memory
-        if (( estimated_memory > memory_limit )); then
-            memory_limit=$estimated_memory
-        fi
+          # If estimated_memory is greater than memory_limit, set memory_limit to estimated_memory
+          if (( estimated_memory > memory_limit )); then
+              memory_limit=$estimated_memory
+          fi
+      fi
     fi
     loginfo "Memory limit set to: $memory_limit GB"
 


### PR DESCRIPTION
Fixes a "division by zero" ark error. The root cause still confuses me but I was unable to reproduce it with these changes.

I also adjusted the math and added a comment of how we were calculating. 