### PR TITLE
ASTRACTL-33864: astra-connector: unable to detect AKS flavor correctly.

### DIFF
--- a/app/deployer/connector/astra_connect_natless.go
+++ b/app/deployer/connector/astra_connect_natless.go
@@ -219,6 +219,11 @@ func (d *AstraConnectDeployer) GetServiceAccountObjects(m *v1.AstraConnector, ct
 func (d *AstraConnectDeployer) GetClusterRoleObjects(m *v1.AstraConnector, ctx context.Context) ([]client.Object, controllerutil.MutateFn, error) {
 	rules := []rbacv1.PolicyRule{
 		{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"clusterroles"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
 			APIGroups: []string{""},
 			Resources: []string{"namespaces", "persistentvolumes", "nodes", "pods", "services"},
 			Verbs:     []string{"watch", "list", "get"},


### PR DESCRIPTION
closes ASTRACTL-33864
* updates astraconnet clusterRole, adds permissions to get/list clusterRoles