### PR TITLE
ASTRACTL-33890: astra-connector: unable to detect OCP flavor correctly.

### DIFF
--- a/app/deployer/connector/astra_connect_natless.go
+++ b/app/deployer/connector/astra_connect_natless.go
@@ -225,6 +225,11 @@ func (d *AstraConnectDeployer) GetServiceAccountObjects(m *v1.AstraConnector, ct
 func (d *AstraConnectDeployer) GetClusterRoleObjects(m *v1.AstraConnector, ctx context.Context) ([]client.Object, controllerutil.MutateFn, error) {
 	rules := []rbacv1.PolicyRule{
 		{
+			APIGroups: []string{"config.openshift.io"},
+			Resources: []string{"clusteroperators"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
 			APIGroups: []string{"rbac.authorization.k8s.io"},
 			Resources: []string{"clusterroles"},
 			Verbs:     []string{"get", "list"},


### PR DESCRIPTION
closes ASTRACTL-33890
* updates astraconnect role with permissions to get, list clusteroperators.config.openshift.io