### PR TITLE
ASTRACTL-33567: split NAMESPACE -> CONNECTOR/TRIDENT_NAMESPACE

### DIFF
--- a/unified-installer/astra-unified-installer.sh
+++ b/unified-installer/astra-unified-installer.sh
@@ -156,7 +156,7 @@ get_configs() {
     KUBECONFIG="${KUBECONFIG}"
     COMPONENTS="${COMPONENTS:-$__COMPONENTS_ALL_ASTRA_CONTROL}" # Determines what we'll install/upgrade
     IMAGE_PULL_SECRET="${IMAGE_PULL_SECRET:-}" # TODO ASTRACTL-32772: skip prompt if IMAGE_REGISTRY is default
-    NAMESPACE="${NAMESPACE:-}" # Overrides EVERY resource's namespace (for fresh installs only, not upgrades)
+    NAMESPACE="${NAMESPACE:-}"
         CONNECTOR_NAMESPACE="$(get_connector_namespace)"
         TRIDENT_NAMESPACE="$(get_trident_namespace)"
     LABELS="${LABELS:-}"
@@ -943,6 +943,9 @@ join_rpath() {
     echo "$joined"
 }
 
+# join_str will use the given separator to join all given args beyond the first.
+# Usage: join_str "," "one" "two" "three"
+# Output: one,two,three
 join_str() {
     local -r separator="${1}"
     local -ar strings_to_join=("${@:2}")


### PR DESCRIPTION
This PR adds `CONNECTOR_NAMESPACE` and `TRIDENT_NAMESPACE`. The original NAMESPACE variable is now just a high level "default", similar to IMAGE_REGISTRY, IMAGE_BASE_REPO, and so on.

There are two "major" changes that were done to achieve this:
- `operators/kustomization.yaml` is now split into two:
    - `operators/connector/kustomization.yaml` - contains all kustomizations related to the connector
    - `operators/trident/kustomization.yaml` - contains all kustomizations related to trident
- The **astra-regcred**, which is the default secret used for authenticating to the Astra registry and is generated by us, is now completely separate from **IMAGE_PULL_SECRET**. This means that:
    -  If we detect any of the image registries are of the Astra flavor, we create **astra-regcred** regardless of what's in **IMAGE_PULL_SECRET**
    - All resources will have their imagePullSecret references set appropriately (will both include **IMAGE_PULL_SECRET** if there is one as well as **astra-regcred** if we found an image hosted on an Astra registry)
    
Also contains a few bug fixes that I encountered while testing -- which, on that topic, included:
- Generic Greenfield test (connector + trident/acp)
- Generic Brownfield test (connector + trident upgrade)
- Generic Brownfield test with DO_NOT_MODIFY_EXISTING_TRIDENT (connector + existing trident left intact)
- Multiple specialized greenfield/brownfield scenarios to make sure pull secrets are being created, including manipulating the list of pull secrets of an existing installation to make sure we correctly add the IMAGE_PULL_SECRET or astra-regcred to the list (if they're mising) during an upgrade